### PR TITLE
First Wave of Rules and Tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# Tabs in JS unless otherwise specified
+[**.js]
+indent_style = tab
+indent_size = 4
+
+[**.jsx]
+indent_style = tab
+indent_size = 4
+
+[**.html]
+indent_style = tab
+indent_size = 4
+
+[**.css]
+indent_style = tab
+indent_size = 4

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,14 @@
+{
+  "extends": "leankit",
+  "rules": {
+    "quote-props": 0,
+    "no-magic-numbers": 0,
+    "prefer-arrow-callback": 0,
+    "no-unused-expressions": 0,
+    "max-nested-callbacks": 0
+  },
+  "globals": {
+    "describe": true,
+    "it": true
+  }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "4.1"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,47 @@
 # eslint-config-leankit
-LeanKit's ESLint config, following our Coding Standards
+
+[![Build Status](https://travis-ci.org/LeanKit-Labs/eslint-config-leankit.svg?branch=master)](https://travis-ci.org/LeanKit-Labs/eslint-config-leankit)
+
+This package provides LeanKit's .eslintrc as an extensible [shared config](http://eslint.org/docs/developer-guide/shareable-configs).
+
+## Usage
+
+We support four ESLint configurations for your usage.
+
+### eslint-config-leankit
+
+Our default export contains the base of our ESLint rules, including ECMAScript 6+. It currently requires only `eslint`.
+
+1. `npm install eslint eslint-config-leankit --save-dev`
+2. add `"extends": "leankit"` to your .eslintrc
+
+### eslint-config-leankit/test
+
+This contains the default configuration and some rules for writing tests using [`mocha`](https://mochajs.org/).
+
+1. `npm install eslint eslint-config-leankit --save-dev`
+2. add `"extends": "leankit/test"` to your .eslintrc
+
+### eslint-config-leankit/legacy
+
+Lints ECMAScript 5 and below. This also only requires `eslint`.
+
+1. `npm install eslint eslint-config-leankit --save-dev`
+2. add `"extends": "leankit/legacy"` to your `.eslintrc`
+
+### eslint-config-leankit/react
+
+This contains all of our ESLint rules, including ECMAScript 6+ and React. It requires `eslint` and `eslint-plugin-react`.
+
+1. `npm install eslint eslint-plugin-react eslint-config-leankit --save-dev`
+2. add `"extends": "leankit/react"` to your .eslintrc
+
+See also [LeanKit's Style Guide](https://github.com/LeanKit-Labs/touchstone/wiki) and
+the [ESLint config documentation](http://eslint.org/docs/user-guide/configuring)
+for more information.
+
+## Tests
+
+You can run tests with `npm test`.
+
+You can make sure this module lints with itself using `npm run lint`.

--- a/base.js
+++ b/base.js
@@ -1,0 +1,12 @@
+module.exports = {
+	"extends": [
+		"eslint-config-leankit/legacy",
+		"eslint-config-leankit/rules/ecmascript6"
+	],
+	"env": {
+		"browser": true,
+		"node": true,
+		"commonjs": true
+	},
+	"rules": {}
+};

--- a/index.js
+++ b/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+	"extends": "eslint-config-leankit/base",
+	"rules": {}
+};

--- a/legacy.js
+++ b/legacy.js
@@ -1,0 +1,17 @@
+module.exports = {
+	"extends": [
+		"eslint-config-leankit/rules/best-practices",
+		"eslint-config-leankit/rules/possible-errors",
+		"eslint-config-leankit/rules/nodejs-and-commonjs",
+		"eslint-config-leankit/rules/strict-mode",
+		"eslint-config-leankit/rules/stylistic-issues",
+		"eslint-config-leankit/rules/variables"
+	],
+	"env": {
+		"browser": true,
+		"node": true
+	},
+	"ecmaFeatures": {},
+	"globals": {},
+	"rules": {}
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "eslint-config-leankit",
+  "version": "1.0.0",
+  "description": "<!-- [![Build Status](https://travis-ci.org/leankit/eslint-config-leankit.svg?branch=master)](https://travis-ci.org/leankit/eslint-config-leankit) -->",
+  "main": "index.js",
+  "scripts": {
+    "lint": "eslint --cache '**/*.js'",
+    "lint-ci": "onchange '**/*.js' -- npm run eslint",
+    "test": "mocha spec/*.js",
+    "test-ci": "mocha -w spec/*.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/elijahmanor/eslint-config-leankit.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/elijahmanor/eslint-config-leankit/issues"
+  },
+  "homepage": "https://github.com/elijahmanor/eslint-config-leankit#readme",
+  "devDependencies": {
+    "chai": "^3.4.1",
+    "eslint": "^1.10.3",
+    "eslint-plugin-react": "^3.11.3",
+    "mocha": "^2.3.4",
+    "polyjuice": "^1.1.4"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,11 +1,9 @@
 {
   "name": "eslint-config-leankit",
   "version": "1.0.0",
-  "description": "<!-- [![Build Status](https://travis-ci.org/leankit/eslint-config-leankit.svg?branch=master)](https://travis-ci.org/leankit/eslint-config-leankit) -->",
+  "description": "ESLint rules for LeanKit",
   "main": "index.js",
   "scripts": {
-    "lint": "eslint --cache '**/*.js'",
-    "lint-ci": "onchange '**/*.js' -- npm run eslint",
     "test": "mocha spec/*.js",
     "test-ci": "mocha -w spec/*.js"
   },
@@ -13,9 +11,13 @@
     "type": "git",
     "url": "git+https://github.com/elijahmanor/eslint-config-leankit.git"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "keywords": [ "lint", "eslint", "leankit" ],
+  "author": "LeanKit",
+  "contributors": [
+    { "name": "Elijah Manor" },
+    { "name": "Bob Yexley" }
+  ],
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/elijahmanor/eslint-config-leankit/issues"
   },
@@ -24,7 +26,6 @@
     "chai": "^3.4.1",
     "eslint": "^1.10.3",
     "eslint-plugin-react": "^3.11.3",
-    "mocha": "^2.3.4",
-    "polyjuice": "^1.1.4"
+    "mocha": "^2.3.4"
   }
 }

--- a/react.js
+++ b/react.js
@@ -3,5 +3,7 @@ module.exports = {
 		"eslint-config-leankit/base",
 		"eslint-config-leankit/rules/react"
 	],
-	"rules": {}
+	"rules": {
+		"complexity": [ 2, 10 ]
+	}
 };

--- a/react.js
+++ b/react.js
@@ -1,0 +1,7 @@
+module.exports = {
+	"extends": [
+		"eslint-config-leankit/base",
+		"eslint-config-leankit/rules/react"
+	],
+	"rules": {}
+};

--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -1,0 +1,64 @@
+// Best Practices http://eslint.org/docs/rules/#best-practices
+
+module.exports = {
+	"rules": {
+		"accessor-pairs": [ 2, { "setWithoutGet": true } ], // enforces getter/setter pairs in objects
+		"block-scoped-var": 2, // JSHINT treat var statements as if they were block scoped
+		"complexity": [ 2, 50 ], // specify the maximum cyclomatic complexity allowed in a program
+		"consistent-return": 2, // require return statements to either always or never specify values
+		"curly": [ 2, "all" ], // JSCS specify curly brace conventions for all control statements
+		"default-case": 2, // require default case in switch statements
+		"dot-location": [ 2, "property" ], // enforces consistent newlines before or after dots
+		"dot-notation": 2, // JSCS encourages use of dot notation whenever possible
+		"eqeqeq": [ 2, "smart" ], // JSHINT require the use of === and !== (fixable)
+		"guard-for-in": 2, // JSHINT make sure for-in loops have an if statement
+		"no-alert": 2, // disallow the use of alert, confirm, and prompt
+		"no-caller": 2, // JSHINT disallow use of arguments.caller or arguments.callee
+		"no-case-declarations": 2, // disallow lexical declarations in case clauses
+		"no-div-regex": 2, // disallow division operators explicitly at beginning of regular expression
+		"no-else-return": 2, // disallow else after a return in an if
+		"no-empty-label": 2, // disallow use of labels for anything other than loops and switches
+		"no-empty-pattern": 2, // disallow use of empty destructuring patterns
+		"no-eq-null": 1, // JSHINT disallow comparisons to null without a type-checking operator
+		"no-eval": 2, // JSHINT disallow use of eval()
+		"no-extend-native": 2, // disallow adding to native types
+		"no-extra-bind": 2, // disallow unnecessary function binding
+		"no-fallthrough": 2, // disallow fallthrough of case statements
+		"no-floating-decimal": 2, // disallow the use of leading or trailing decimal points in numeric literals
+		"no-implicit-coercion": 0, // disallow the type conversions with shorter notations
+		"no-implied-eval": 2, // disallow use of eval()-like methods
+		"no-invalid-this": 2, // JSHINT disallow this keywords outside of classes or class-like objects
+		"no-iterator": 2, // JSHINT disallow usage of __iterator__ property
+		"no-labels": 2, // disallow use of labeled statements
+		"no-lone-blocks": 2, // disallow unnecessary nested blocks
+		"no-loop-func": 2, // JSHINT disallow creation of functions within loops
+		"no-magic-numbers": 2, // disallow the use of magic numbers
+		"no-multi-spaces": 2, // JSCS disallow use of multiple spaces (fixable)
+		"no-multi-str": 2, // JSCS disallow use of multiline strings
+		"no-native-reassign": 2, // disallow reassignments of native objects
+		"no-new-func": 2, // JSHINT disallow use of new operator for Function object
+		"no-new-wrappers": 2, // JSHINT disallows creating new instances of String,Number, and Boolean
+		"no-new": 2, // JSHINT disallow use of the new operator when not part of an assignment or comparison
+		"no-octal-escape": 2, // disallow use of octal escape sequences in string literals, such as var foo = "Copyright \251";
+		"no-octal": 2, // disallow use of octal literals
+		"no-param-reassign": [ 1, { "props": false } ], // disallow reassignment of function parameters
+		"no-process-env": 1, // disallow use of process.env
+		"no-proto": 2, // JSHINT disallow usage of __proto__ property
+		"no-redeclare": 2, // disallow declaring the same variable more than once
+		"no-return-assign": 2, // disallow use of assignment in return statement
+		"no-script-url": 2, // JSHINT disallow use of javascript: urls.
+		"no-self-compare": 2, // disallow comparisons where both sides are exactly the same
+		"no-sequences": 2, // disallow use of the comma operator
+		"no-throw-literal": 2, // restrict what can be thrown as an exception
+		"no-unused-expressions": 2, // JSHINT disallow usage of expressions in statement position
+		"no-useless-call": 2, // disallow unnecessary .call() and .apply()
+		"no-useless-concat": 2, // disallow unnecessary concatenation of literals or template literals
+		"no-void": 2, // disallow use of the void operator
+		"no-warning-comments": [ 0, { "terms": [ "todo", "fixme", "xxx" ], "location": "start" } ], // disallow usage of configurable warning terms in comments - e.g. TODO or FIXME
+		"no-with": 2, // JSCS disallow use of the with statement
+		"radix": 2, // require use of the second argument for parseInt()
+		"vars-on-top": 2, // require declaration of all vars at the top of their containing scope
+		"wrap-iife": 2, // JSCS require immediate function invocation to be wrapped in parentheses
+		"yoda": 2 // require or disallow Yoda conditions
+	}
+};

--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -4,7 +4,7 @@ module.exports = {
 	"rules": {
 		"accessor-pairs": [ 2, { "setWithoutGet": true } ], // enforces getter/setter pairs in objects
 		"block-scoped-var": 2, // JSHINT treat var statements as if they were block scoped
-		"complexity": [ 2, 50 ], // specify the maximum cyclomatic complexity allowed in a program
+		"complexity": [ 2, 5 ], // specify the maximum cyclomatic complexity allowed in a program
 		"consistent-return": 2, // require return statements to either always or never specify values
 		"curly": [ 2, "all" ], // JSCS specify curly brace conventions for all control statements
 		"default-case": 2, // require default case in switch statements

--- a/rules/ecmascript6.js
+++ b/rules/ecmascript6.js
@@ -1,0 +1,52 @@
+// ECMAScript 6 http://eslint.org/docs/rules/#ecmascript-6
+
+module.exports = {
+	"env": {
+		"es6": true
+	},
+	"ecmaFeatures": {
+		"arrowFunctions": true, // enable arrow functions
+		"binaryLiterals": true, // enable binary literals
+		"blockBindings": true, // enable let and const
+		"classes": true, // enable classes
+		"defaultParams": true, // enable default function parameters
+		"destructuring": true, // enable destructuring
+		"forOf": true, // enable for-of loops
+		"generators": true, // enable generators
+		"modules": true, // enable modules and global strict mode
+		"objectLiteralComputedProperties": true, // enable computed object literal property names
+		"objectLiteralDuplicateProperties": true, // enable duplicate object literal properties in strict mode
+		"objectLiteralShorthandMethods": true, // enable object literal shorthand methods
+		"objectLiteralShorthandProperties": true, // enable object literal shorthand properties
+		"octalLiterals": false, // enable octal literals
+		"regexUFlag": true, // enable the regular expression u flag
+		"regexYFlag": true, // enable the regular expression y flag
+		"restParams": true, // enable the rest parameters
+		"spread": true, // enable the spread operator for arrays
+		"superInFunctions": true, // enable super references inside of functions
+		"templateStrings": true, // enable template strings
+		"unicodeCodePointEscapes": true, // enable code point escapes
+		"globalReturn": false, // allow return statements in the global scope
+		"jsx": true, // enable JSX
+		"experimentalObjectRestSpread": true // enable support for the experimental object rest/spread properties
+	},
+	"rules": {
+		"arrow-body-style": [ 2, "as-needed" ], // require braces in arrow function body
+		"arrow-parens": [ 2, "always" ], // require parens in arrow function arguments
+		"arrow-spacing": [ 2, { "before": true, "after": true } ], // require space before/after arrow function's arrow (fixable)
+		"constructor-super": 2, // verify calls of super() in constructors
+		"generator-star-spacing": [ 2, { "before": true, "after": false } ], // enforce spacing around the * in generator functions (fixable)
+		"no-class-assign": 2, // disallow modifying variables of class declarations
+		"no-const-assign": 2, // disallow modifying variables that are declared using const
+		"no-dupe-class-members": 2, // disallow duplicate name in class members
+		"no-this-before-super": 2, // disallow use of this/super before calling super() in constructors
+		"no-var": 2, // require let or const instead of var
+		"object-shorthand": [ 2, "always" ], // require method and property shorthand syntax for object literals
+		"prefer-arrow-callback": 2, // suggest using arrow functions as callbacks
+		"prefer-const": 2, // suggest using const declaration for variables that are never modified after declared
+		"prefer-reflect": 0, // suggest using Reflect methods where applicable
+		"prefer-spread": 2, // suggest using the spread operator instead of .apply()
+		"prefer-template": 2, // suggest using template literals instead of strings concatenation
+		"require-yield": 2 // disallow generator functions that do not have yield
+	}
+};

--- a/rules/ecmascript6.js
+++ b/rules/ecmascript6.js
@@ -31,7 +31,7 @@ module.exports = {
 		"experimentalObjectRestSpread": true // enable support for the experimental object rest/spread properties
 	},
 	"rules": {
-		"arrow-body-style": [ 2, "as-needed" ], // require braces in arrow function body
+		"arrow-body-style": [ 1, "as-needed" ], // require braces in arrow function body
 		"arrow-parens": [ 2, "always" ], // require parens in arrow function arguments
 		"arrow-spacing": [ 2, { "before": true, "after": true } ], // require space before/after arrow function's arrow (fixable)
 		"constructor-super": 2, // verify calls of super() in constructors

--- a/rules/nodejs-and-commonjs.js
+++ b/rules/nodejs-and-commonjs.js
@@ -1,0 +1,15 @@
+// Node.js and CommonJS http://eslint.org/docs/rules/#nodejs-and-commonjs
+
+module.exports = {
+	"rules": {
+		"callback-return": 2, // enforce return after a callback
+		"global-require": 2, // enforce require() on top-level module scope
+		"handle-callback-err": 0, // enforce require() on top-level module scope
+		"no-mixed-requires": [ 2, { "grouping": true } ], //  enforce error handling in callbacks
+		"no-new-require": 2, //  disallow mixing regular variable and require declarations
+		"no-path-concat": 2, // disallow string concatenation with __dirname and __filename
+		"no-process-exit": 2, // disallow process.exit()
+		"no-restricted-modules": 0, // restrict usage of specified node modules
+		"no-sync": 0 //  disallow use of synchronous methods
+	}
+};

--- a/rules/possible-errors.js
+++ b/rules/possible-errors.js
@@ -1,0 +1,34 @@
+// Possible Errors http://eslint.org/docs/rules/#possible-errors
+
+module.exports = {
+	"rules": {
+		"comma-dangle": [ 2, "never" ], // JSCS disallow or enforce trailing commas
+		"no-cond-assign": [ 2, "always" ], // JSHINT disallow assignment in conditional expressions
+		"no-console": 2, // disallow use of console in the node environment
+		"no-constant-condition": 2, // disallow use of constant expressions in conditions
+		"no-control-regex": 2, // disallow control characters in regular expressions
+		"no-debugger": 2, // JSHINT disallow use of debugger
+		"no-dupe-args": 2, // disallow duplicate arguments in functions
+		"no-dupe-keys": 2, // disallow duplicate keys when creating object literals
+		"no-duplicate-case": 2, // disallow a duplicate case label
+		"no-empty-character-class": 2, // disallow the use of empty character classes in regular expressions
+		"no-empty": 2, // JSHINT disallow empty statements
+		"no-ex-assign": 2, // disallow assigning to the exception in a catch block
+		"no-extra-boolean-cast": 2, // disallow double-negation boolean casts in a boolean context
+		"no-extra-parens": 1, // disallow unnecessary parentheses
+		"no-extra-semi": 2, // disallow unnecessary semicolons (fixable)
+		"no-func-assign": 2, // disallow overwriting functions written as function declarations
+		"no-inner-declarations": 2, // disallow function or variable declarations in nested blocks
+		"no-invalid-regexp": 2, // disallow invalid regular expression strings in the RegExp constructor
+		"no-irregular-whitespace": 2, // disallow irregular whitespace outside of strings and comments
+		"no-negated-in-lhs": 2, // disallow negation of the left operand of an in expression
+		"no-obj-calls": 2, // disallow the use of object properties of the global object (Math and JSON) as functions
+		"no-regex-spaces": 2, // disallow multiple spaces in a regular expression literal
+		"no-sparse-arrays": 2, //  disallow sparse arrays
+		"no-unexpected-multiline": 2, //  Avoid code that looks like two expressions but is actually one
+		"no-unreachable": 2, // disallow unreachable statements after a return, throw, continue, or break statement
+		"use-isnan": 2, // disallow comparisons with the value NaN
+		"valid-jsdoc": 2, // Ensure JSDoc comments are valid
+		"valid-typeof": 2 // Ensure that the results of typeof are compared against a valid string
+	}
+};

--- a/rules/react.js
+++ b/rules/react.js
@@ -1,0 +1,68 @@
+// eslint-plugin-react https://github.com/yannickcr/eslint-plugin-react
+
+module.exports = {
+	"plugins": [ "react" ],
+	"rules": {
+		"react/display-name": [ 2, { "acceptTranspilerName": true } ], // Prevent missing displayName in a React component definition
+		"react/forbid-prop-types": [ 2, { "forbid": [ "any" ] } ], // Forbid certain propTypes
+		"react/jsx-boolean-value": [ 1, "always" ], // Enforce boolean attributes notation in JSX
+		"react/jsx-closing-bracket-location": [ 1, { "location": "after-props" } ], // Validate closing bracket location in JSX
+		"react/jsx-curly-spacing": [ 2, "always" ], // Enforce or disallow spaces inside of curly braces in JSX attributes
+		"react/jsx-handler-names": [ 1, { "eventHandlerPrefix": "handle", "eventHandlerPropPrefix": "on" } ], // Enforce event handler naming conventions in JSX
+		"react/jsx-indent-props": [ 2, "tab" ], // Validate props indentation in JSX
+		"react/jsx-key": [ 2, 2 ], // Validate JSX has key prop when in array or iterator
+		"react/jsx-max-props-per-line": [ 2, { "maximum": 10 } ], // Limit maximum of props on a single line in JSX
+		"react/jsx-no-bind": [ 0 ], // Prevent usage of .bind() and arrow functions in JSX props
+		"react/jsx-no-duplicate-props": [ 2, { "ignoreCase": false } ], // Prevent duplicate props in JSX
+		"react/jsx-no-literals": 1, // Prevent usage of unwrapped JSX strings
+		"react/jsx-no-undef": 2, // Disallow undeclared variables in JSX
+		"react/jsx-pascal-case": 0, // Enforce PascalCase for user-defined JSX components
+		"react/jsx-quotes": [ 2, "double", "avoid-escape" ], // Enforce quote style for JSX attributes
+		"react/jsx-sort-prop-types": 0, // Enforce propTypes declarations alphabetical sorting
+		"react/jsx-sort-props": 0, // Enforce props alphabetical sorting
+		"react/jsx-uses-react": 2, // Prevent React to be incorrectly marked as unused
+		"react/jsx-uses-vars": 2, // Prevent variables used in JSX to be incorrectly marked as unused
+		"react/no-danger": 2, // Prevent usage of dangerous JSX properties
+		"react/no-did-mount-set-state": [ 2, "allow-in-func" ], // Prevent usage of setState in componentDidMount
+		"react/no-did-update-set-state": 2, // Prevent usage of setState in componentDidUpdate
+		"react/no-direct-mutation-state": 2, // Prevent direct mutation of this.state
+		"react/no-multi-comp": [ 2, { "ignoreStateless": true } ], // Prevent multiple component definition per file
+		"react/no-set-state": 0, // Prevent usage of setState
+		"react/no-unknown-property": 2, // Prevent usage of unknown DOM property
+		"react/prefer-es6-class": 0, // Prefer es6 class instead of createClass for React Components
+		"react/prop-types": 2, // Prevent missing props validation in a React component definition
+		"react/react-in-jsx-scope": 2, // Prevent missing React when using JSX
+		"react/require-extension": 2, // Restrict file extensions that may be required
+		"react/self-closing-comp": 2, // Prevent extra closing tags for components without children
+		"react/sort-comp": [ 1, {
+			"order": [
+				"lifecycle",
+				"everything-else",
+				"render"
+			],
+			"groups": {
+				"lifecycle": [
+					"displayName",
+					"mixins",
+					"propTypes",
+					"contextTypes",
+					"childContextTypes",
+					"statics",
+					"defaultProps",
+					"constructor",
+					"getDefaultProps",
+					"getInitialState",
+					"getChildContext",
+					"componentWillMount",
+					"componentDidMount",
+					"componentWillReceiveProps",
+					"shouldComponentUpdate",
+					"componentWillUpdate",
+					"componentDidUpdate",
+					"componentWillUnmount"
+				]
+			}
+		} ], // Enforce component methods order
+		"react/wrap-multilines": 2 // Prevent missing parentheses around multilines JSX
+	}
+};

--- a/rules/strict-mode.js
+++ b/rules/strict-mode.js
@@ -1,0 +1,7 @@
+// Strict Mode http://eslint.org/docs/rules/#strict-mode
+
+module.exports = {
+	"rules": {
+		"strict": [ 2, "never" ] // controls location of Use Strict Directives
+	}
+};

--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -1,0 +1,70 @@
+// Stylistic Issues http://eslint.org/docs/rules/#stylistic-issues
+
+module.exports = {
+	"rules": {
+		"array-bracket-spacing": [ 2, "always" ], // JSCS enforce spacing inside array brackets (fixable)
+		"block-spacing": [ 2, "always" ], // disallow or enforce spaces inside of single line blocks (fixable)
+		"brace-style": [ 2, "1tbs" ], // JSCS enforce one true brace style
+		"camelcase": [ 2, { "properties": "always" } ], // JSCS require camel case names
+		"comma-spacing": [ 2, { "before": false, "after": true } ], // enforce spacing before and after comma (fixable)
+		"comma-style": [ 2, "last" ], // JSCS enforce one true comma style
+		"computed-property-spacing": [ 2, "always" ], // require or disallow padding inside computed properties (fixable)
+		"consistent-this": [ 2, "self" ], // enforce consistent naming when capturing the current execution context
+		"eol-last": 2, // JSCS enforce newline at the end of file, with no multiple empty lines (fixable)
+		"func-names": 0, // require function expressions to have a name
+		"func-style": 0, // enforce use of function declarations or expressions
+		"id-length": [ 2, { "min": 1, "max": 100, "properties": "always", "exceptions": [] } ], // this option enforces minimum and maximum identifier lengths (variable names, property names etc.)
+		"id-match": 0, // require identifiers to match the provided regular expression
+		"indent": [ 2, "tab", { "SwitchCase": 1 } ], // JSCS specify tab or space width for your code (fixable)
+		"jsx-quotes": [ 2, "prefer-double" ], // specify whether double or single quotes should be used in JSX attributes
+		"key-spacing": [ 2, { "beforeColon": false, "afterColon": true } ], // JSCS enforce spacing between keys and values in object literal properties
+		"linebreak-style": [ 2, "unix" ], // JSCS disallow mixed 'LF' and 'CRLF' as linebreaks
+		"lines-around-comment": 0, // JSCS enforce empty lines around comments
+		"max-depth": [ 2, 5 ], // specify the maximum depth that blocks can be nested
+		"max-len": 0, // specify the maximum length of a line in your program
+		"max-nested-callbacks": [ 2, 3 ], // specify the maximum depth callbacks can be nested
+		"max-params": [ 2, 5 ], // limits the number of parameters that can be used in the function declaration.
+		"max-statements": [ 2, 25 ], // specify the maximum number of statement allowed in a function
+		"new-cap": 2, // JSCS require a capital letter for constructors
+		"new-parens": 2, // disallow the omission of parentheses when invoking a constructor with no arguments
+		"newline-after-var": [ 1, "always" ], // require or disallow an empty newline after variable declarations
+		"no-array-constructor": 2, // disallow use of the Array constructor
+		"no-bitwise": 0, // JSHINT disallow use of bitwise operators
+		"no-continue": 2, // disallow use of the continue statement
+		"no-inline-comments": 0, // disallow comments inline after code
+		"no-lonely-if": 2, // disallow if as the only statement in an else block
+		"no-mixed-spaces-and-tabs": 2, // JSCS disallow mixed spaces and tabs for indentation
+		"no-multiple-empty-lines": [ 2, { max: 2 } ], // JSCS disallow multiple empty lines
+		"no-negated-condition": 2, // disallow negated conditions
+		"no-nested-ternary": 2, // disallow nested ternary expressions
+		"no-new-object": 2, // disallow the use of the Object constructor
+		"no-plusplus": 0, // JSHINT disallow use of unary operators, ++ and --
+		"no-restricted-syntax": [ 2, "WithStatement" ], // disallow use of certain syntax in code
+		"no-spaced-func": 2, // JSCS disallow space between function identifier and application (fixable)
+		"no-ternary": 0, // disallow the use of ternary operators
+		"no-trailing-spaces": 2, // JSCS disallow trailing whitespace at the end of lines (fixable)
+		"no-underscore-dangle": 0, // disallow dangling underscores in identifiers
+		"no-unneeded-ternary": 2, // disallow the use of ternary operators when a simpler alternative exists
+		"object-curly-spacing": [ 2, "always" ], // require or disallow padding inside curly braces (fixable)
+		"one-var": [ 2, { "initialized": "never", "uninitialized": "always" } ], // JSCS require or disallow one variable declaration per function
+		"operator-assignment": [ 1, "always" ], // require assignment operator shorthand where possible or prohibit it entirely
+		"operator-linebreak": [ 2, "after", { "overrides": { "?": "after", ":": "after" } } ], // JSCS enforce operators to be placed before or after line breaks
+		"padded-blocks": [ 2, "never" ], // JSCS enforce padding within blocks
+		"quote-props": [ 2, "as-needed", { "keywords": true } ], // JSCS require quotes around object literal property names
+		"quotes": [ 2, "double", "avoid-escape" ], // JSCS specify whether backticks, double or single quotes should be used (fixable)
+		"require-jsdoc": [ 0 ], // Require JSDoc comment
+		"semi-spacing": [ 2, { "before": false, "after": true } ], // enforce spacing before and after semicolons
+		"semi": [ 2, "always" ], // JSCS require or disallow use of semicolons instead of ASI (fixable)
+		"sort-vars": 0, // sort variables within the same declaration block
+		"space-after-keywords": [ 2, "always" ], // JSCS require a space after certain keywords (fixable)
+		"space-before-blocks": [ 2, "always" ], // JSCS require or disallow a space before blocks (fixable)
+		"space-before-function-paren": [ 2, "never" ], // JSCS require or disallow a space before function opening parenthesis (fixable)
+		"space-before-keywords": [ 2, "always" ], // require a space before certain keywords (fixable)
+		"space-in-parens": [ 2, "always" ], // JSCS require or disallow spaces inside parentheses
+		"space-infix-ops": 2, // JSCS require spaces around operators (fixable)
+		"space-return-throw-case": 2, // JSCS require a space after return, throw, and case (fixable)
+		"space-unary-ops": 2, // JSCS require or disallow spaces before/after unary operators (fixable)
+		"spaced-comment": [ 2, "always" ], // require or disallow a space immediately following the // or /* in a comment
+		"wrap-regex": 0 // require regex literals to be wrapped in parentheses
+	}
+};

--- a/rules/variables.js
+++ b/rules/variables.js
@@ -1,0 +1,17 @@
+// Variables http://eslint.org/docs/rules/#variables
+
+module.exports = {
+	"rules": {
+		"init-declarations": [ 1, "always" ], //  enforce or disallow variable initializations at definition
+		"no-catch-shadow": 2, // disallow the catch clause parameter name being the same as a variable in the outer scope
+		"no-delete-var": 2, // disallow deletion of variables
+		"no-label-var": 2, // disallow labels that share a name with a variable
+		"no-shadow-restricted-names": 2, // disallow shadowing of names such as arguments
+		"no-shadow": 2, // JSHINT disallow declaration of variables already declared in the outer scope
+		"no-undef-init": 2, // disallow use of undefined when initializing variables
+		"no-undef": 2, // JSHINT disallow use of undeclared variables unless mentioned in a /*global */ block
+		"no-undefined": 0, // disallow use of undefined variable
+		"no-unused-vars": [ 2, { "vars": "all", "args": "after-used" } ], // JSHINT disallow declaration of variables that are not used in the code
+		"no-use-before-define": [ 2, "nofunc" ] // JSHINT disallow use of variables before they are defined
+	}
+};

--- a/spec/base.js
+++ b/spec/base.js
@@ -1,0 +1,23 @@
+const should = require( "chai" ).should();
+const rules = require( "../base" );
+const environments = [ "browser", "node", "commonjs" ];
+
+describe( "Base", function() {
+	describe( "Rules", function() {
+		it( "should extend legacy rules", function() {
+			rules.extends.should.contain( "eslint-config-leankit/legacy" );
+		} );
+
+		it( "should extend ecmascript6 rules", function() {
+			rules.extends.should.contain( "eslint-config-leankit/rules/ecmascript6" );
+		} );
+	} );
+
+	describe( "Environment", function() {
+		it( "should define environments", function() {
+			environments.forEach( function( key ) {
+				should.exist( rules.env[ key ] );
+			} );
+		} );
+	} );
+} );

--- a/spec/index.js
+++ b/spec/index.js
@@ -1,0 +1,9 @@
+const rules = require( "../index" );
+
+describe( "Index", function() {
+	describe( "Rules", function() {
+		it( "should extend base rules", function() {
+			rules.extends.should.contain( "eslint-config-leankit/base" );
+		} );
+	} );
+} );

--- a/spec/legacy.js
+++ b/spec/legacy.js
@@ -1,0 +1,39 @@
+const should = require( "chai" ).should();
+const rules = require( "../legacy" );
+const environments = [ "browser", "node" ];
+
+describe( "Legacy", function() {
+	describe( "Rules", function() {
+		it( "should extend best-practices rules", function() {
+			rules.extends.should.contain( "eslint-config-leankit/rules/best-practices" );
+		} );
+
+		it( "should extend possible-errors rules", function() {
+			rules.extends.should.contain( "eslint-config-leankit/rules/possible-errors" );
+		} );
+
+		it( "should extend nodejs-and-commonjs rules", function() {
+			rules.extends.should.contain( "eslint-config-leankit/rules/nodejs-and-commonjs" );
+		} );
+
+		it( "should extend strict rules", function() {
+			rules.extends.should.contain( "eslint-config-leankit/rules/strict-mode" );
+		} );
+
+		it( "should extend stylistic-issues rules", function() {
+			rules.extends.should.contain( "eslint-config-leankit/rules/stylistic-issues" );
+		} );
+
+		it( "should extend variables rules", function() {
+			rules.extends.should.contain( "eslint-config-leankit/rules/variables" );
+		} );
+	} );
+
+	describe( "Environment", function() {
+		it( "should define environments", function() {
+			environments.forEach( function( key ) {
+				should.exist( rules.env[ key ] );
+			} );
+		} );
+	} );
+} );

--- a/spec/react.js
+++ b/spec/react.js
@@ -1,0 +1,13 @@
+const rules = require( "../react" );
+
+describe( "React", function() {
+	describe( "Rules", function() {
+		it( "should extend base rules", function() {
+			rules.extends.should.contain( "eslint-config-leankit/base" );
+		} );
+
+		it( "should extend react rules", function() {
+			rules.extends.should.contain( "eslint-config-leankit/rules/react" );
+		} );
+	} );
+} );

--- a/spec/test.js
+++ b/spec/test.js
@@ -1,0 +1,33 @@
+const should = require( "chai" ).should();
+const rules = require( "../test" );
+const globals = [ "before", "beforeEach", "describe", "global", "it", "sinon", "should" ];
+
+describe( "Test", function() {
+	describe( "Rules", function() {
+		it( "should extend base rules", function() {
+			rules.extends.should.contain( "eslint-config-leankit/base" );
+		} );
+	} );
+
+	describe( "Environment", function() {
+		it( "should define browser", function() {
+			rules.env.browser.should.be.true;
+		} );
+
+		it( "should define node", function() {
+			rules.env.node.should.be.true;
+		} );
+
+		it( "should define mocha", function() {
+			rules.env.mocha.should.be.true;
+		} );
+	} );
+
+	describe( "Globals", function() {
+		it( "should define global constiables", function() {
+			globals.forEach( function( key ) {
+				should.exist( rules.globals[ key ] );
+			} );
+		} );
+	} );
+} );

--- a/test.js
+++ b/test.js
@@ -1,0 +1,24 @@
+module.exports = {
+	"extends": "eslint-config-leankit/base",
+	"env": {
+		"browser": true,
+		"node": true,
+		"mocha": true
+	},
+	"globals": {
+		"before": true,
+		"beforeEach": true,
+		"describe": true,
+		"global": true,
+		"it": true,
+		"sinon": true,
+		"should": true
+	},
+	"rules": {
+		"max-nested-callbacks": [ 2, 15 ],
+		"no-unused-expressions": 0,
+		"no-magic-numbers": 0,
+		"react/prop-types": 0,
+		"react/display-name": 0
+	}
+};


### PR DESCRIPTION
The reason this project was made is to add linting rules that we didn't have defined in ESLint previously and provide them in a way that we can leverage them in our public and private repos.

The way that you can do that is by installing this repo into your project `npm i eslint eslint-config-leankit -D` and adding an `"extends": "leankit"` to your .eslintrc file. You can also tap into custom .eslintrc configurations such as `react`, 'test', or 'legacy' rules (`"extends": "leankit/react"`, etc... see README.md).

We started by converting current JSHint and JSCS configurations to a set of ESLint rules using the [polyjuice](https://www.npmjs.com/package/polyjuice) library.

For rules that came from JSHint or JSCS we added a comment in that rule that it came from there. We also listed which rules are fixable by ESLint. Our hope is that we could possibly remove the JSCS dependency and use ESLint for both linting needs. If we find a gap in stylistic rules then a good approach could be to contribute to ESLint.
