### PR TITLE
Feature/rule updates

### DIFF
--- a/legacy.js
+++ b/legacy.js
@@ -13,5 +13,7 @@ module.exports = {
 	},
 	"ecmaFeatures": {},
 	"globals": {},
-	"rules": {}
+	"rules": {
+		"vars-on-top": 0
+	}
 };

--- a/react.js
+++ b/react.js
@@ -4,6 +4,6 @@ module.exports = {
 		"eslint-config-leankit/rules/react"
 	],
 	"rules": {
-		"complexity": [ 2, 10 ]
+		"complexity": [ 0, 10 ] // TRIAL
 	}
 };

--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -41,8 +41,8 @@ module.exports = {
 		"no-new": 2, // JSHINT disallow use of the new operator when not part of an assignment or comparison
 		"no-octal-escape": 2, // disallow use of octal escape sequences in string literals, such as var foo = "Copyright \251";
 		"no-octal": 2, // disallow use of octal literals
-		"no-process-env": 1, // disallow use of process.env
 		"no-param-reassign": [ 0, { "props": false } ], // TRIAL disallow reassignment of function parameters
+		"no-process-env": 0, // disallow use of process.env
 		"no-proto": 2, // JSHINT disallow usage of __proto__ property
 		"no-redeclare": 2, // disallow declaring the same variable more than once
 		"no-return-assign": 2, // disallow use of assignment in return statement

--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -4,7 +4,7 @@ module.exports = {
 	"rules": {
 		"accessor-pairs": [ 2, { "setWithoutGet": true } ], // enforces getter/setter pairs in objects
 		"block-scoped-var": 2, // JSHINT treat var statements as if they were block scoped
-		"complexity": [ 2, 5 ], // specify the maximum cyclomatic complexity allowed in a program
+		"complexity": [ 0, 5 ], // TRIAL specify the maximum cyclomatic complexity allowed in a program
 		"consistent-return": 2, // require return statements to either always or never specify values
 		"curly": [ 2, "all" ], // JSCS specify curly brace conventions for all control statements
 		"default-case": 2, // require default case in switch statements
@@ -41,8 +41,8 @@ module.exports = {
 		"no-new": 2, // JSHINT disallow use of the new operator when not part of an assignment or comparison
 		"no-octal-escape": 2, // disallow use of octal escape sequences in string literals, such as var foo = "Copyright \251";
 		"no-octal": 2, // disallow use of octal literals
-		"no-param-reassign": [ 1, { "props": false } ], // disallow reassignment of function parameters
 		"no-process-env": 1, // disallow use of process.env
+		"no-param-reassign": [ 0, { "props": false } ], // TRIAL disallow reassignment of function parameters
 		"no-proto": 2, // JSHINT disallow usage of __proto__ property
 		"no-redeclare": 2, // disallow declaring the same variable more than once
 		"no-return-assign": 2, // disallow use of assignment in return statement

--- a/rules/ecmascript6.js
+++ b/rules/ecmascript6.js
@@ -31,7 +31,7 @@ module.exports = {
 		"experimentalObjectRestSpread": true // enable support for the experimental object rest/spread properties
 	},
 	"rules": {
-		"arrow-body-style": [ 1, "as-needed" ], // require braces in arrow function body
+		"arrow-body-style": [ 0, "as-needed" ], // TRIAL require braces in arrow function body
 		"arrow-parens": [ 2, "as-needed" ], // require parens in arrow function arguments
 		"arrow-spacing": [ 2, { "before": true, "after": true } ], // require space before/after arrow function's arrow (fixable)
 		"constructor-super": 2, // verify calls of super() in constructors

--- a/rules/ecmascript6.js
+++ b/rules/ecmascript6.js
@@ -32,7 +32,7 @@ module.exports = {
 	},
 	"rules": {
 		"arrow-body-style": [ 1, "as-needed" ], // require braces in arrow function body
-		"arrow-parens": [ 2, "always" ], // require parens in arrow function arguments
+		"arrow-parens": [ 2, "as-needed" ], // require parens in arrow function arguments
 		"arrow-spacing": [ 2, { "before": true, "after": true } ], // require space before/after arrow function's arrow (fixable)
 		"constructor-super": 2, // verify calls of super() in constructors
 		"generator-star-spacing": [ 2, { "before": true, "after": false } ], // enforce spacing around the * in generator functions (fixable)

--- a/rules/possible-errors.js
+++ b/rules/possible-errors.js
@@ -4,7 +4,7 @@ module.exports = {
 	"rules": {
 		"comma-dangle": [ 2, "never" ], // JSCS disallow or enforce trailing commas
 		"no-cond-assign": [ 2, "always" ], // JSHINT disallow assignment in conditional expressions
-		"no-console": 2, // disallow use of console in the node environment
+		"no-console": 1, // disallow use of console in the node environment
 		"no-constant-condition": 2, // disallow use of constant expressions in conditions
 		"no-control-regex": 2, // disallow control characters in regular expressions
 		"no-debugger": 2, // JSHINT disallow use of debugger

--- a/rules/react.js
+++ b/rules/react.js
@@ -8,13 +8,13 @@ module.exports = {
 		"react/jsx-boolean-value": [ 1, "always" ], // Enforce boolean attributes notation in JSX
 		"react/jsx-closing-bracket-location": [ 1, { "location": "after-props" } ], // Validate closing bracket location in JSX
 		"react/jsx-curly-spacing": [ 2, "always" ], // Enforce or disallow spaces inside of curly braces in JSX attributes
-		"react/jsx-handler-names": [ 0, { "eventHandlerPrefix": "handle", "eventHandlerPropPrefix": "on" } ], // Enforce event handler naming conventions in JSX
+		"react/jsx-handler-names": [ 0, { "eventHandlerPrefix": "handle", "eventHandlerPropPrefix": "on" } ], // TRIAL Enforce event handler naming conventions in JSX
 		"react/jsx-indent-props": [ 2, "tab" ], // Validate props indentation in JSX
 		"react/jsx-key": [ 2, 2 ], // Validate JSX has key prop when in array or iterator
 		"react/jsx-max-props-per-line": [ 2, { "maximum": 10 } ], // Limit maximum of props on a single line in JSX
 		"react/jsx-no-bind": [ 0 ], // Prevent usage of .bind() and arrow functions in JSX props
 		"react/jsx-no-duplicate-props": [ 2, { "ignoreCase": false } ], // Prevent duplicate props in JSX
-		"react/jsx-no-literals": 1, // Prevent usage of unwrapped JSX strings
+		"react/jsx-no-literals": 0, // Prevent usage of unwrapped JSX strings
 		"react/jsx-no-undef": 2, // Disallow undeclared variables in JSX
 		"react/jsx-pascal-case": 0, // Enforce PascalCase for user-defined JSX components
 		"react/jsx-quotes": [ 2, "double", "avoid-escape" ], // Enforce quote style for JSX attributes
@@ -36,32 +36,24 @@ module.exports = {
 		"react/self-closing-comp": 2, // Prevent extra closing tags for components without children
 		"react/sort-comp": [ 1, {
 			"order": [
-				"lifecycle",
+				"mixins",
+				"lux",
+				"props",
+				"state",
 				"everything-else",
 				"render"
 			],
 			"groups": {
-				"lifecycle": [
-					"displayName",
-					"mixins",
+				"lux": [
 					"stores",
-					"getActions",
+					"getActions"
+				],
+				"props": [
 					"propTypes",
-					"contextTypes",
-					"childContextTypes",
-					"statics",
-					"defaultProps",
-					"constructor",
 					"getDefaultProps",
-					"getInitialState",
-					"getChildContext",
-					"componentWillMount",
-					"componentDidMount",
-					"componentWillReceiveProps",
-					"shouldComponentUpdate",
-					"componentWillUpdate",
-					"componentDidUpdate",
-					"componentWillUnmount"
+				],
+				"state": [
+					"getInitialState"
 				]
 			}
 		} ], // Enforce component methods order

--- a/rules/react.js
+++ b/rules/react.js
@@ -44,6 +44,8 @@ module.exports = {
 				"lifecycle": [
 					"displayName",
 					"mixins",
+					"stores",
+					"getActions",
 					"propTypes",
 					"contextTypes",
 					"childContextTypes",

--- a/rules/react.js
+++ b/rules/react.js
@@ -8,7 +8,7 @@ module.exports = {
 		"react/jsx-boolean-value": [ 1, "always" ], // Enforce boolean attributes notation in JSX
 		"react/jsx-closing-bracket-location": [ 1, { "location": "after-props" } ], // Validate closing bracket location in JSX
 		"react/jsx-curly-spacing": [ 2, "always" ], // Enforce or disallow spaces inside of curly braces in JSX attributes
-		"react/jsx-handler-names": [ 1, { "eventHandlerPrefix": "handle", "eventHandlerPropPrefix": "on" } ], // Enforce event handler naming conventions in JSX
+		"react/jsx-handler-names": [ 0, { "eventHandlerPrefix": "handle", "eventHandlerPropPrefix": "on" } ], // Enforce event handler naming conventions in JSX
 		"react/jsx-indent-props": [ 2, "tab" ], // Validate props indentation in JSX
 		"react/jsx-key": [ 2, 2 ], // Validate JSX has key prop when in array or iterator
 		"react/jsx-max-props-per-line": [ 2, { "maximum": 10 } ], // Limit maximum of props on a single line in JSX

--- a/rules/react.js
+++ b/rules/react.js
@@ -46,6 +46,7 @@ module.exports = {
 			"groups": {
 				"lux": [
 					"stores",
+					"getActionGroup",
 					"getActions"
 				],
 				"props": [

--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -27,7 +27,7 @@ module.exports = {
 		"max-statements": [ 2, 25 ], // specify the maximum number of statement allowed in a function
 		"new-cap": 2, // JSCS require a capital letter for constructors
 		"new-parens": 2, // disallow the omission of parentheses when invoking a constructor with no arguments
-		"newline-after-var": [ 1, "always" ], // require or disallow an empty newline after variable declarations
+		"newline-after-var": [ 2, "always" ], // require or disallow an empty newline after variable declarations
 		"no-array-constructor": 2, // disallow use of the Array constructor
 		"no-bitwise": 0, // JSHINT disallow use of bitwise operators
 		"no-continue": 2, // disallow use of the continue statement
@@ -47,10 +47,10 @@ module.exports = {
 		"no-unneeded-ternary": 2, // disallow the use of ternary operators when a simpler alternative exists
 		"object-curly-spacing": [ 2, "always" ], // require or disallow padding inside curly braces (fixable)
 		"one-var": [ 2, { "initialized": "never", "uninitialized": "always" } ], // JSCS require or disallow one variable declaration per function
-		"operator-assignment": [ 1, "always" ], // require assignment operator shorthand where possible or prohibit it entirely
+		"operator-assignment": [ 2, "always" ], // require assignment operator shorthand where possible or prohibit it entirely
 		"operator-linebreak": [ 2, "after", { "overrides": { "?": "after", ":": "after" } } ], // JSCS enforce operators to be placed before or after line breaks
 		"padded-blocks": [ 2, "never" ], // JSCS enforce padding within blocks
-		"quote-props": [ 2, "as-needed", { "keywords": true } ], // JSCS require quotes around object literal property names
+		"quote-props": [ 2, "as-needed", { "keywords": false } ], // JSCS require quotes around object literal property names
 		"quotes": [ 2, "double", "avoid-escape" ], // JSCS specify whether backticks, double or single quotes should be used (fixable)
 		"require-jsdoc": [ 0 ], // Require JSDoc comment
 		"semi-spacing": [ 2, { "before": false, "after": true } ], // enforce spacing before and after semicolons

--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -35,7 +35,7 @@ module.exports = {
 		"no-lonely-if": 2, // disallow if as the only statement in an else block
 		"no-mixed-spaces-and-tabs": 2, // JSCS disallow mixed spaces and tabs for indentation
 		"no-multiple-empty-lines": [ 2, { max: 2 } ], // JSCS disallow multiple empty lines
-		"no-negated-condition": 2, // disallow negated conditions
+		"no-negated-condition": 0, // TRIAL disallow negated conditions
 		"no-nested-ternary": 2, // disallow nested ternary expressions
 		"no-new-object": 2, // disallow the use of the Object constructor
 		"no-plusplus": 0, // JSHINT disallow use of unary operators, ++ and --

--- a/rules/variables.js
+++ b/rules/variables.js
@@ -11,7 +11,7 @@ module.exports = {
 		"no-undef-init": 2, // disallow use of undefined when initializing variables
 		"no-undef": 2, // JSHINT disallow use of undeclared variables unless mentioned in a /*global */ block
 		"no-undefined": 0, // disallow use of undefined variable
-		"no-unused-vars": [ 2, { "vars": "all", "args": "after-used" } ], // JSHINT disallow declaration of variables that are not used in the code
+		"no-unused-vars": [ 2, { "vars": "all", "args": "none" } ], // JSHINT disallow declaration of variables that are not used in the code
 		"no-use-before-define": [ 2, "nofunc" ] // JSHINT disallow use of variables before they are defined
 	}
 };

--- a/rules/variables.js
+++ b/rules/variables.js
@@ -2,7 +2,7 @@
 
 module.exports = {
 	"rules": {
-		"init-declarations": [ 1, "always" ], //  enforce or disallow variable initializations at definition
+		"init-declarations": [ 2, "always" ], //  enforce or disallow variable initializations at definition
 		"no-catch-shadow": 2, // disallow the catch clause parameter name being the same as a variable in the outer scope
 		"no-delete-var": 2, // disallow deletion of variables
 		"no-label-var": 2, // disallow labels that share a name with a variable

--- a/test.js
+++ b/test.js
@@ -19,6 +19,8 @@ module.exports = {
 		"no-unused-expressions": 0,
 		"no-magic-numbers": 0,
 		"react/prop-types": 0,
-		"react/display-name": 0
+		"react/display-name": 0,
+		"react/no-multi-comp": 0,
+		"init-declarations": 0
 	}
 };


### PR DESCRIPTION
This is a process improvement task to continue updating our code quality tooling (eslint) rules to better catch problems in JavaScript.

Per the notes from the prior PR Review:
- `no-unused-vars` -> unused method args are OK, unused declarations are not
- `no-console` should be a warning
- `react/no-multi-comp` ignored for tests
- `no-process-env` should be ignored (allow process.env)
- trial balloons
  - `no-negated-condition`
  - `complexity` thresholds
  - `no-param-reassign`
  - `react/jsx-handler-names`
  - `react/jsx-no-literals`
  - `arrow-body-style`
- hoisting var rules are ES6 specific (`vars-on-top`) (turn off for legacy)
- convert to errors
  - `newline-after-var`
  - `init-declarations` (but disable in test)
  - `operator-assignment` (enforce shorthand)
  - set `arrow-parens` rule to as needed
  - `quote-props` set to as needed (keywords false)
  - `react/sort-comp` - reduce to targeted subset:
    - mixins
    - lux
    - props
    - state
    - everything else?
    - render (at bottom)
