### PR TITLE
Minor Tweaks to eslint-config-leankit based previous implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## 1.0.x
 
+### Next
+
+* Minor Tweaks to `eslint-config-leankit` based on lessons learned when integrating the rules into `nonstop-index-ui`
+* Turned off the following rules: `react/jsx-handler-names`, `no-extra-parens`, `react/jsx-boolean-value`, `no-eq-null`, `newline-after-var`
+* Update the following rules: `react/sort-comp`, `react/jsx-quotes`
+* Turn this warning into an error: `react/sort-comp`
+* There are 4 remaining TRIAL rules: `complexity`, `arrow-body-style`, `no-negated-condition`, `no-extra-parens`
+
 ### 1.0.0
 
 Initial Release

--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -19,7 +19,7 @@ module.exports = {
 		"no-else-return": 2, // disallow else after a return in an if
 		"no-empty-label": 2, // disallow use of labels for anything other than loops and switches
 		"no-empty-pattern": 2, // disallow use of empty destructuring patterns
-		"no-eq-null": 1, // JSHINT disallow comparisons to null without a type-checking operator
+		"no-eq-null": 0, // JSHINT disallow comparisons to null without a type-checking operator
 		"no-eval": 2, // JSHINT disallow use of eval()
 		"no-extend-native": 2, // disallow adding to native types
 		"no-extra-bind": 2, // disallow unnecessary function binding
@@ -41,7 +41,7 @@ module.exports = {
 		"no-new": 2, // JSHINT disallow use of the new operator when not part of an assignment or comparison
 		"no-octal-escape": 2, // disallow use of octal escape sequences in string literals, such as var foo = "Copyright \251";
 		"no-octal": 2, // disallow use of octal literals
-		"no-param-reassign": [ 0, { "props": false } ], // TRIAL disallow reassignment of function parameters
+		"no-param-reassign": [ 0, { "props": false } ], // disallow reassignment of function parameters
 		"no-process-env": 0, // disallow use of process.env
 		"no-proto": 2, // JSHINT disallow usage of __proto__ property
 		"no-redeclare": 2, // disallow declaring the same variable more than once

--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -41,7 +41,7 @@ module.exports = {
 		"no-new": 2, // JSHINT disallow use of the new operator when not part of an assignment or comparison
 		"no-octal-escape": 2, // disallow use of octal escape sequences in string literals, such as var foo = "Copyright \251";
 		"no-octal": 2, // disallow use of octal literals
-		"no-param-reassign": [ 0, { "props": false } ], // disallow reassignment of function parameters
+		"no-param-reassign": [ 0, { "props": false } ], // TRIAL disallow reassignment of function parameters
 		"no-process-env": 0, // disallow use of process.env
 		"no-proto": 2, // JSHINT disallow usage of __proto__ property
 		"no-redeclare": 2, // disallow declaring the same variable more than once

--- a/rules/possible-errors.js
+++ b/rules/possible-errors.js
@@ -4,7 +4,7 @@ module.exports = {
 	"rules": {
 		"comma-dangle": [ 2, "never" ], // JSCS disallow or enforce trailing commas
 		"no-cond-assign": [ 2, "always" ], // JSHINT disallow assignment in conditional expressions
-		"no-console": 1, // disallow use of console in the node environment
+		"no-console": 2, // disallow use of console in the node environment
 		"no-constant-condition": 2, // disallow use of constant expressions in conditions
 		"no-control-regex": 2, // disallow control characters in regular expressions
 		"no-debugger": 2, // JSHINT disallow use of debugger
@@ -15,7 +15,7 @@ module.exports = {
 		"no-empty": 2, // JSHINT disallow empty statements
 		"no-ex-assign": 2, // disallow assigning to the exception in a catch block
 		"no-extra-boolean-cast": 2, // disallow double-negation boolean casts in a boolean context
-		"no-extra-parens": 1, // disallow unnecessary parentheses
+		"no-extra-parens": 0, // TRIAL disallow unnecessary parentheses
 		"no-extra-semi": 2, // disallow unnecessary semicolons (fixable)
 		"no-func-assign": 2, // disallow overwriting functions written as function declarations
 		"no-inner-declarations": 2, // disallow function or variable declarations in nested blocks

--- a/rules/possible-errors.js
+++ b/rules/possible-errors.js
@@ -4,7 +4,7 @@ module.exports = {
 	"rules": {
 		"comma-dangle": [ 2, "never" ], // JSCS disallow or enforce trailing commas
 		"no-cond-assign": [ 2, "always" ], // JSHINT disallow assignment in conditional expressions
-		"no-console": 2, // disallow use of console in the node environment
+		"no-console": 1, // disallow use of console in the node environment
 		"no-constant-condition": 2, // disallow use of constant expressions in conditions
 		"no-control-regex": 2, // disallow control characters in regular expressions
 		"no-debugger": 2, // JSHINT disallow use of debugger

--- a/rules/react.js
+++ b/rules/react.js
@@ -5,10 +5,10 @@ module.exports = {
 	"rules": {
 		"react/display-name": [ 2, { "acceptTranspilerName": true } ], // Prevent missing displayName in a React component definition
 		"react/forbid-prop-types": [ 2, { "forbid": [ "any" ] } ], // Forbid certain propTypes
-		"react/jsx-boolean-value": [ 1, "always" ], // Enforce boolean attributes notation in JSX
+		"react/jsx-boolean-value": [ 0, "always" ], // Enforce boolean attributes notation in JSX
 		"react/jsx-closing-bracket-location": [ 1, { "location": "after-props" } ], // Validate closing bracket location in JSX
 		"react/jsx-curly-spacing": [ 2, "always" ], // Enforce or disallow spaces inside of curly braces in JSX attributes
-		"react/jsx-handler-names": [ 0, { "eventHandlerPrefix": "handle", "eventHandlerPropPrefix": "on" } ], // TRIAL Enforce event handler naming conventions in JSX
+		"react/jsx-handler-names": [ 0, { "eventHandlerPrefix": "handle", "eventHandlerPropPrefix": "on" } ], // Enforce event handler naming conventions in JSX
 		"react/jsx-indent-props": [ 2, "tab" ], // Validate props indentation in JSX
 		"react/jsx-key": [ 2, 2 ], // Validate JSX has key prop when in array or iterator
 		"react/jsx-max-props-per-line": [ 2, { "maximum": 10 } ], // Limit maximum of props on a single line in JSX
@@ -17,7 +17,6 @@ module.exports = {
 		"react/jsx-no-literals": 0, // Prevent usage of unwrapped JSX strings
 		"react/jsx-no-undef": 2, // Disallow undeclared variables in JSX
 		"react/jsx-pascal-case": 0, // Enforce PascalCase for user-defined JSX components
-		"react/jsx-quotes": [ 2, "double", "avoid-escape" ], // Enforce quote style for JSX attributes
 		"react/jsx-sort-prop-types": 0, // Enforce propTypes declarations alphabetical sorting
 		"react/jsx-sort-props": 0, // Enforce props alphabetical sorting
 		"react/jsx-uses-react": 2, // Prevent React to be incorrectly marked as unused
@@ -34,7 +33,7 @@ module.exports = {
 		"react/react-in-jsx-scope": 2, // Prevent missing React when using JSX
 		"react/require-extension": 2, // Restrict file extensions that may be required
 		"react/self-closing-comp": 2, // Prevent extra closing tags for components without children
-		"react/sort-comp": [ 1, {
+		"react/sort-comp": [ 2, {
 			"order": [
 				"mixins",
 				"lux",
@@ -45,9 +44,9 @@ module.exports = {
 			],
 			"groups": {
 				"lux": [
-					"stores",
 					"getActionGroup",
-					"getActions"
+					"getActions",
+					"stores"
 				],
 				"props": [
 					"propTypes",

--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -27,7 +27,7 @@ module.exports = {
 		"max-statements": [ 2, 25 ], // specify the maximum number of statement allowed in a function
 		"new-cap": 2, // JSCS require a capital letter for constructors
 		"new-parens": 2, // disallow the omission of parentheses when invoking a constructor with no arguments
-		"newline-after-var": [ 2, "always" ], // require or disallow an empty newline after variable declarations
+		"newline-after-var": [ 0, "always" ], // require or disallow an empty newline after variable declarations
 		"no-array-constructor": 2, // disallow use of the Array constructor
 		"no-bitwise": 0, // JSHINT disallow use of bitwise operators
 		"no-continue": 2, // disallow use of the continue statement


### PR DESCRIPTION
Minor Tweaks to `eslint-config-leankit` based on lessons learned when integrating the rules into `nonstop-index-ui`
## Turned off the following rules
- `react/jsx-handler-names` - it turns out this is problematic when using `lux` actions directly
- `no-extra-parens` - make this a trial rule as grouping can help make code clearer and it can conflict with the `react/wrap-multilines` rule making an override necessary
- `react/jsx-boolean-value` - it is redundant to enforce this rule
- `no-param-reassign` - this is done frequently and the fix bloats the code
- `no-eq-null` - this edgecase is infrequent and `!= null` to indicate `null` and `undefined` is nice
- `newline-after-var` - this is done frequently and feels very nit picky
## Update the following rules
- `react/sort-comp` - swap getActions/getActionGroup and stores
- `react/jsx-quotes` is deprecated and should use `jsx-quotes` instead
## Turn all warnings into errors

Warnings should just be considered as errors. 
- `no-console`
- `react/sort-comp`
## There are 4 remaining TRIAL rules

These rules are marked as `// TRIAL` in this repo and it is up to the consumer to turn these rules on and experiment with their options. If we come to an agreement on these rules then they'll be turned on in a future update.
- `complexity`
- `arrow-body-style`
- `no-negated-condition`
- `no-extra-parens`
