### PR TITLE
Upgrade to eslint 2.0.*

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,22 +13,23 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/elijahmanor/eslint-config-leankit.git"
+    "url": "git+https://github.com/LeanKit-Labs/eslint-config-leankit.git"
   },
   "keywords": [ "lint", "eslint", "leankit" ],
   "author": "LeanKit",
   "contributors": [
     { "name": "Elijah Manor" },
-    { "name": "Bob Yexley" }
+    { "name": "Bob Yexley" },
+    { "name": "JD Courtoy" }
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/elijahmanor/eslint-config-leankit/issues"
+    "url": "https://github.com/LeanKit-Labs/eslint-config-leankit/issues"
   },
-  "homepage": "https://github.com/elijahmanor/eslint-config-leankit#readme",
+  "homepage": "https://github.com/LeanKit-Labs/eslint-config-leankit#readme",
   "devDependencies": {
     "chai": "^3.4.1",
-    "eslint": "^1.10.3",
+    "eslint": "^2.0.0",
     "eslint-plugin-react": "^3.11.3",
     "mocha": "^2.3.4"
   }

--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -17,7 +17,6 @@ module.exports = {
 		"no-case-declarations": 2, // disallow lexical declarations in case clauses
 		"no-div-regex": 2, // disallow division operators explicitly at beginning of regular expression
 		"no-else-return": 2, // disallow else after a return in an if
-		"no-empty-label": 2, // disallow use of labels for anything other than loops and switches
 		"no-empty-pattern": 2, // disallow use of empty destructuring patterns
 		"no-eq-null": 0, // JSHINT disallow comparisons to null without a type-checking operator
 		"no-eval": 2, // JSHINT disallow use of eval()
@@ -32,7 +31,9 @@ module.exports = {
 		"no-labels": 2, // disallow use of labeled statements
 		"no-lone-blocks": 2, // disallow unnecessary nested blocks
 		"no-loop-func": 2, // JSHINT disallow creation of functions within loops
-		"no-magic-numbers": 2, // disallow the use of magic numbers
+		"no-magic-numbers": [ "error", {
+			"ignore": [ -1, 0, 1 ] // disallow the use of magic numbers except common incrementers / indexes
+		} ],
 		"no-multi-spaces": 2, // JSCS disallow use of multiple spaces (fixable)
 		"no-multi-str": 2, // JSCS disallow use of multiline strings
 		"no-native-reassign": 2, // disallow reassignments of native objects

--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -18,6 +18,15 @@ module.exports = {
 		"indent": [ 2, "tab", { "SwitchCase": 1 } ], // JSCS specify tab or space width for your code (fixable)
 		"jsx-quotes": [ 2, "prefer-double" ], // specify whether double or single quotes should be used in JSX attributes
 		"key-spacing": [ 2, { "beforeColon": false, "afterColon": true } ], // JSCS enforce spacing between keys and values in object literal properties
+		"keyword-spacing": [ 2, {
+			"before": true, // require a space before certain keywords (fixable)
+			"after": true, // JSCS require a space after certain keywords (fixable)
+			"overrides": { // JSCS require a space after return, throw, and case (fixable)
+				"return": { "after": true },
+				"throw": { "after": true },
+				"case": { "after": true }
+			}
+		} ], //
 		"linebreak-style": [ 2, "unix" ], // JSCS disallow mixed 'LF' and 'CRLF' as linebreaks
 		"lines-around-comment": 0, // JSCS enforce empty lines around comments
 		"max-depth": [ 2, 5 ], // specify the maximum depth that blocks can be nested
@@ -56,13 +65,10 @@ module.exports = {
 		"semi-spacing": [ 2, { "before": false, "after": true } ], // enforce spacing before and after semicolons
 		"semi": [ 2, "always" ], // JSCS require or disallow use of semicolons instead of ASI (fixable)
 		"sort-vars": 0, // sort variables within the same declaration block
-		"space-after-keywords": [ 2, "always" ], // JSCS require a space after certain keywords (fixable)
 		"space-before-blocks": [ 2, "always" ], // JSCS require or disallow a space before blocks (fixable)
 		"space-before-function-paren": [ 2, "never" ], // JSCS require or disallow a space before function opening parenthesis (fixable)
-		"space-before-keywords": [ 2, "always" ], // require a space before certain keywords (fixable)
 		"space-in-parens": [ 2, "always" ], // JSCS require or disallow spaces inside parentheses
 		"space-infix-ops": 2, // JSCS require spaces around operators (fixable)
-		"space-return-throw-case": 2, // JSCS require a space after return, throw, and case (fixable)
 		"space-unary-ops": 2, // JSCS require or disallow spaces before/after unary operators (fixable)
 		"spaced-comment": [ 2, "always" ], // require or disallow a space immediately following the // or /* in a comment
 		"wrap-regex": 0 // require regex literals to be wrapped in parentheses

--- a/test.js
+++ b/test.js
@@ -4,7 +4,7 @@ module.exports = {
 		"mocha": true
 	},
 	"ecmaFeatures": {
-		"modules": true, // enable modules and global strict mode
+		"modules": true // enable modules and global strict mode
 	},
 	"globals": {
 		"before": true,


### PR DESCRIPTION
Updated so that we can use the newer eslint version in our common config since the newer projects are already using eslint 2.0 by way of dependency tree.

 biggulp@1.2.0 => gulp-eslint@2.0.0 => eslint@2.7.0 
