### PR TITLE
Removed unneeded configuration from test.js

### DIFF
--- a/spec/test.js
+++ b/spec/test.js
@@ -1,20 +1,11 @@
 const should = require( "chai" ).should();
 const rules = require( "../test" );
-const globals = [ "before", "beforeEach", "describe", "global", "it", "sinon", "should" ];
 const IGNORED_RULES = [ "no-unused-expressions", "no-magic-numbers", "react/prop-types", "react/display-name", "react/no-multi-comp", "init-declarations" ];
 
 describe( "Test", function() {
 	describe( "Environment", function() {
 		it( "should define mocha", function() {
 			rules.env.mocha.should.be.true;
-		} );
-	} );
-
-	describe( "Globals", function() {
-		it( "should define global constiables", function() {
-			globals.forEach( function( key ) {
-				should.exist( rules.globals[ key ] );
-			} );
 		} );
 	} );
 

--- a/test.js
+++ b/test.js
@@ -1,19 +1,6 @@
 module.exports = {
 	"env": {
-		"es6": true,
 		"mocha": true
-	},
-	"ecmaFeatures": {
-		"modules": true // enable modules and global strict mode
-	},
-	"globals": {
-		"before": true,
-		"beforeEach": true,
-		"describe": true,
-		"global": true,
-		"it": true,
-		"sinon": true,
-		"should": true
 	},
 	"rules": {
 		"max-nested-callbacks": [ 2, 15 ],


### PR DESCRIPTION
- Mocha globals are added by `env.mocha=true` 
- `global` is added by `env.node=true` and if the project extends "leankit" then they already have this
- `sinon`, `should` and `expect` should be added explicitly in the project, if needed

My thought is that globals that are explicitly added in the project as opposed to being part of the environment setup (i.e. by node, mocha, etc) should be explicitly added to project configuration, but I'd like to hear what @elijahmanor thinks as well.
