### PR TITLE
Feature update with our jscs settings

### DIFF
--- a/rules/a11y.js
+++ b/rules/a11y.js
@@ -3,29 +3,29 @@
 module.exports = {
 	"plugins": [ "jsx-a11y" ],
 	"rules": {
-		"jsx-a11y/anchor-has-content": 2, // Enforce all anchors to contain accessible content.
-		"jsx-a11y/aria-props": 2, // Enforce all aria-* props are valid.
-		"jsx-a11y/aria-proptypes": 2, // Enforce ARIA state and property values are valid.
-		"jsx-a11y/aria-role": 2, // Enforce that elements with ARIA roles must use a valid, non-abstract ARIA role.
-		"jsx-a11y/aria-unsupported-elements": 2, // Enforce that elements that do not support ARIA roles, states, and properties do not have those attributes.
-		"jsx-a11y/click-events-have-key-events": 2, // Enforce a clickable non-interactive element has at least one keyboard event listener.
-		"jsx-a11y/heading-has-content": 2, // Enforce heading (h1, h2, etc) elements contain accessible content.
-		"jsx-a11y/href-no-hash": 2, // Enforce an anchor element's href prop value is not just #.
-		"jsx-a11y/html-has-lang": 2, // Enforce <html> element has lang prop.
-		"jsx-a11y/img-has-alt": 2, // Enforce that <img> JSX elements use the alt prop.
-		"jsx-a11y/img-redundant-alt": 2, // Enforce <img> alt prop does not contain the word "image", "picture", or "photo".
-		"jsx-a11y/label-has-for": 2, // Enforce that <label> elements have the htmlFor prop.
-		"jsx-a11y/lang": 2, // Enforce lang attribute has a valid value.
-		"jsx-a11y/mouse-events-have-key-events": 2, // Enforce that onMouseOver/onMouseOut are accompanied by onFocus/onBlur for keyboard-only users.
-		"jsx-a11y/no-access-key": 2, // Enforce that the accessKey prop is not used on any element to avoid complications with keyboard commands used by a screenreader.
-		"jsx-a11y/no-marquee": 2, // Enforce <marquee> elements are not used.
-		"jsx-a11y/no-onchange": 2, // Enforce usage of onBlur over onChange on select menus for accessibility.
-		"jsx-a11y/no-static-element-interactions": 2, // Enforce non-interactive elements have no interactive handlers.
-		"jsx-a11y/onclick-has-focus": 2, // Enforce that elements with onClick handlers must be focusable.
-		"jsx-a11y/onclick-has-role": 2, // Enforce that non-interactive, visible elements (such as <div>) that have click handlers use the role attribute.
-		"jsx-a11y/role-has-required-aria-props": 2, // Enforce that elements with ARIA roles must have all required attributes for that role.
-		"jsx-a11y/role-supports-aria-props": 2, // Enforce that elements with explicit or implicit roles defined contain only aria-* properties supported by that role.
-		"jsx-a11y/scope": 2, // Enforce scope prop is only used on <th> elements.
-		"jsx-a11y/tabindex-no-positive": 2 // Enforce tabIndex value is not greater than zero.
+		"jsx-a11y/anchor-has-content": "error", // Enforce all anchors to contain accessible content.
+		"jsx-a11y/aria-props": "error", // Enforce all aria-* props are valid.
+		"jsx-a11y/aria-proptypes": "error", // Enforce ARIA state and property values are valid.
+		"jsx-a11y/aria-role": "error", // Enforce that elements with ARIA roles must use a valid, non-abstract ARIA role.
+		"jsx-a11y/aria-unsupported-elements": "error", // Enforce that elements that do not support ARIA roles, states, and properties do not have those attributes.
+		"jsx-a11y/click-events-have-key-events": "error", // Enforce a clickable non-interactive element has at least one keyboard event listener.
+		"jsx-a11y/heading-has-content": "error", // Enforce heading (h1, h2, etc) elements contain accessible content.
+		"jsx-a11y/href-no-hash": "error", // Enforce an anchor element's href prop value is not just #.
+		"jsx-a11y/html-has-lang": "error", // Enforce <html> element has lang prop.
+		"jsx-a11y/img-has-alt": "error", // Enforce that <img> JSX elements use the alt prop.
+		"jsx-a11y/img-redundant-alt": "error", // Enforce <img> alt prop does not contain the word "image", "picture", or "photo".
+		"jsx-a11y/label-has-for": "error", // Enforce that <label> elements have the htmlFor prop.
+		"jsx-a11y/lang": "error", // Enforce lang attribute has a valid value.
+		"jsx-a11y/mouse-events-have-key-events": "error", // Enforce that onMouseOver/onMouseOut are accompanied by onFocus/onBlur for keyboard-only users.
+		"jsx-a11y/no-access-key": "error", // Enforce that the accessKey prop is not used on any element to avoid complications with keyboard commands used by a screenreader.
+		"jsx-a11y/no-marquee": "error", // Enforce <marquee> elements are not used.
+		"jsx-a11y/no-onchange": "error", // Enforce usage of onBlur over onChange on select menus for accessibility.
+		"jsx-a11y/no-static-element-interactions": "error", // Enforce non-interactive elements have no interactive handlers.
+		"jsx-a11y/onclick-has-focus": "error", // Enforce that elements with onClick handlers must be focusable.
+		"jsx-a11y/onclick-has-role": "error", // Enforce that non-interactive, visible elements (such as <div>) that have click handlers use the role attribute.
+		"jsx-a11y/role-has-required-aria-props": "error", // Enforce that elements with ARIA roles must have all required attributes for that role.
+		"jsx-a11y/role-supports-aria-props": "error", // Enforce that elements with explicit or implicit roles defined contain only aria-* properties supported by that role.
+		"jsx-a11y/scope": "error", // Enforce scope prop is only used on <th> elements.
+		"jsx-a11y/tabindex-no-positive": "error" // Enforce tabIndex value is not greater than zero.
 	}
 };

--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -11,7 +11,7 @@ module.exports = {
 		"curly": [ "error", "all" ], // JSCS specify curly brace conventions for all control statements
 		"default-case": "error", // require default case in switch statements
 		"dot-location": [ "error", "property" ], // enforces consistent newlines before or after dots
-		"dot-notation": "error", // JSCS encourages use of dot notation whenever possible
+		"dot-notation": [ "error", { "allowPattern": "^[a-z]+(_[a-z]+)+$" } ], // JSCS encourages use of dot notation whenever possible
 		"eqeqeq": [ "error", "smart" ], // JSHINT require the use of === and !== (fixable)
 		"guard-for-in": "error", // JSHINT make sure for-in loops have an if statement
 		"no-alert": "error", // disallow the use of alert, confirm, and prompt

--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -2,72 +2,72 @@
 
 module.exports = {
 	"rules": {
-		"accessor-pairs": [ 2, { "setWithoutGet": true } ], // enforces getter/setter pairs in objects
-		"array-callback-return": 2, // enforce return statements in callbacks of array methods
-		"block-scoped-var": 2, // JSHINT treat var statements as if they were block scoped
-		"class-methods-use-this": 0, // enforce that class methods utilize this
-		"complexity": [ 0, 5 ], // TRIAL specify the maximum cyclomatic complexity allowed in a program
-		"consistent-return": 2, // require return statements to either always or never specify values
-		"curly": [ 2, "all" ], // JSCS specify curly brace conventions for all control statements
-		"default-case": 2, // require default case in switch statements
-		"dot-location": [ 2, "property" ], // enforces consistent newlines before or after dots
-		"dot-notation": 2, // JSCS encourages use of dot notation whenever possible
-		"eqeqeq": [ 2, "smart" ], // JSHINT require the use of === and !== (fixable)
-		"guard-for-in": 2, // JSHINT make sure for-in loops have an if statement
-		"no-alert": 2, // disallow the use of alert, confirm, and prompt
-		"no-caller": 2, // JSHINT disallow use of arguments.caller or arguments.callee
-		"no-case-declarations": 2, // disallow lexical declarations in case clauses
-		"no-div-regex": 2, // disallow division operators explicitly at beginning of regular expression
-		"no-else-return": 2, // disallow else after a return in an if
-		"no-empty-function": 0, // disallow empty functions
-		"no-empty-pattern": 2, // disallow use of empty destructuring patterns
-		"no-eq-null": 0, // JSHINT disallow comparisons to null without a type-checking operator
-		"no-eval": 2, // JSHINT disallow use of eval()
-		"no-extend-native": 2, // disallow adding to native types
-		"no-extra-bind": 2, // disallow unnecessary function binding
-		"no-extra-label": 2, // disallow unnecessary labels
-		"no-fallthrough": 2, // disallow fallthrough of case statements
-		"no-floating-decimal": 2, // disallow the use of leading or trailing decimal points in numeric literals
-		"no-global-assign": 2, // disallow assignments to native objects or read-only global variables
-		"no-implicit-coercion": 0, // disallow the type conversions with shorter notations
-		"no-implicit-globals": 0, // disallow var and named function declarations in the global scope
-		"no-implied-eval": 2, // disallow use of eval()-like methods
-		"no-invalid-this": 2, // JSHINT disallow this keywords outside of classes or class-like objects
-		"no-iterator": 2, // JSHINT disallow usage of __iterator__ property
-		"no-labels": 2, // disallow use of labeled statements
-		"no-lone-blocks": 2, // disallow unnecessary nested blocks
-		"no-loop-func": 2, // JSHINT disallow creation of functions within loops
+		"accessor-pairs": [ "error", { "setWithoutGet": true } ], // enforces getter/setter pairs in objects
+		"array-callback-return": "error", // enforce return statements in callbacks of array methods
+		"block-scoped-var": "error", // JSHINT treat var statements as if they were block scoped
+		"class-methods-use-this": "off", // enforce that class methods utilize this
+		"complexity": [ "off", 5 ], // TRIAL specify the maximum cyclomatic complexity allowed in a program
+		"consistent-return": "error", // require return statements to either always or never specify values
+		"curly": [ "error", "all" ], // JSCS specify curly brace conventions for all control statements
+		"default-case": "error", // require default case in switch statements
+		"dot-location": [ "error", "property" ], // enforces consistent newlines before or after dots
+		"dot-notation": "error", // JSCS encourages use of dot notation whenever possible
+		"eqeqeq": [ "error", "smart" ], // JSHINT require the use of === and !== (fixable)
+		"guard-for-in": "error", // JSHINT make sure for-in loops have an if statement
+		"no-alert": "error", // disallow the use of alert, confirm, and prompt
+		"no-caller": "error", // JSHINT disallow use of arguments.caller or arguments.callee
+		"no-case-declarations": "error", // disallow lexical declarations in case clauses
+		"no-div-regex": "error", // disallow division operators explicitly at beginning of regular expression
+		"no-else-return": "error", // disallow else after a return in an if
+		"no-empty-function": "off", // disallow empty functions
+		"no-empty-pattern": "error", // disallow use of empty destructuring patterns
+		"no-eq-null": "off", // JSHINT disallow comparisons to null without a type-checking operator
+		"no-eval": "error", // JSHINT disallow use of eval()
+		"no-extend-native": "error", // disallow adding to native types
+		"no-extra-bind": "error", // disallow unnecessary function binding
+		"no-extra-label": "error", // disallow unnecessary labels
+		"no-fallthrough": "error", // disallow fallthrough of case statements
+		"no-floating-decimal": "error", // disallow the use of leading or trailing decimal points in numeric literals
+		"no-global-assign": "error", // disallow assignments to native objects or read-only global variables
+		"no-implicit-coercion": "off", // disallow the type conversions with shorter notations
+		"no-implicit-globals": "off", // disallow var and named function declarations in the global scope
+		"no-implied-eval": "error", // disallow use of eval()-like methods
+		"no-invalid-this": "error", // JSHINT disallow this keywords outside of classes or class-like objects
+		"no-iterator": "error", // JSHINT disallow usage of __iterator__ property
+		"no-labels": "error", // disallow use of labeled statements
+		"no-lone-blocks": "error", // disallow unnecessary nested blocks
+		"no-loop-func": "error", // JSHINT disallow creation of functions within loops
 		"no-magic-numbers": [ "error", {
 			"ignore": [ -1, 0, 1 ] // disallow the use of magic numbers except common incrementers / indexes
 		} ],
-		"no-multi-spaces": 2, // JSCS disallow use of multiple spaces (fixable)
-		"no-multi-str": 2, // JSCS disallow use of multiline strings
-		"no-new-func": 2, // JSHINT disallow use of new operator for Function object
-		"no-new-wrappers": 2, // JSHINT disallows creating new instances of String,Number, and Boolean
-		"no-new": 2, // JSHINT disallow use of the new operator when not part of an assignment or comparison
-		"no-octal-escape": 2, // disallow use of octal escape sequences in string literals, such as var foo = "Copyright \251";
-		"no-octal": 2, // disallow use of octal literals
-		"no-param-reassign": [ 0, { "props": false } ], // TRIAL disallow reassignment of function parameters
-		"no-proto": 2, // JSHINT disallow usage of __proto__ property
-		"no-redeclare": 2, // disallow declaring the same variable more than once
-		"no-return-assign": 2, // disallow use of assignment in return statement
-		"no-script-url": 2, // JSHINT disallow use of javascript: urls.
-		"no-self-assign": 2, // disallow assignments where both sides are exactly the same
-		"no-self-compare": 2, // disallow comparisons where both sides are exactly the same
-		"no-sequences": 2, // disallow use of the comma operator
-		"no-throw-literal": 2, // restrict what can be thrown as an exception
-		"no-unmodified-loop-condition": 2, // disallow unmodified loop conditions
-		"no-unused-expressions": 2, // JSHINT disallow usage of expressions in statement position
-		"no-unused-labels": 2, // disallow unused labels
-		"no-useless-call": 2, // disallow unnecessary .call() and .apply()
-		"no-useless-concat": 2, // disallow unnecessary concatenation of literals or template literals
-		"no-useless-escape": 2, // disallow unnecessary escape characters
-		"no-void": 2, // disallow use of the void operator
-		"no-warning-comments": [ 0, { "terms": [ "todo", "fixme", "xxx" ], "location": "start" } ], // disallow usage of configurable warning terms in comments - e.g. TODO or FIXME
-		"no-with": 2, // JSCS disallow use of the with statement
-		"radix": 2, // require use of the second argument for parseInt()
-		"vars-on-top": 0, // require declaration of all vars at the top of their containing scope
-		"wrap-iife": 2, // JSCS require immediate function invocation to be wrapped in parentheses
-		"yoda": 2 // require or disallow Yoda conditions
+		"no-multi-spaces": "error", // JSCS disallow use of multiple spaces (fixable)
+		"no-multi-str": "error", // JSCS disallow use of multiline strings
+		"no-new-func": "error", // JSHINT disallow use of new operator for Function object
+		"no-new-wrappers": "error", // JSHINT disallows creating new instances of String,Number, and Boolean
+		"no-new": "error", // JSHINT disallow use of the new operator when not part of an assignment or comparison
+		"no-octal-escape": "error", // disallow use of octal escape sequences in string literals, such as var foo = "Copyright \251";
+		"no-octal": "error", // disallow use of octal literals
+		"no-param-reassign": [ "off", { "props": false } ], // TRIAL disallow reassignment of function parameters
+		"no-proto": "error", // JSHINT disallow usage of __proto__ property
+		"no-redeclare": "error", // disallow declaring the same variable more than once
+		"no-return-assign": "error", // disallow use of assignment in return statement
+		"no-script-url": "error", // JSHINT disallow use of javascript: urls.
+		"no-self-assign": "error", // disallow assignments where both sides are exactly the same
+		"no-self-compare": "error", // disallow comparisons where both sides are exactly the same
+		"no-sequences": "error", // disallow use of the comma operator
+		"no-throw-literal": "error", // restrict what can be thrown as an exception
+		"no-unmodified-loop-condition": "error", // disallow unmodified loop conditions
+		"no-unused-expressions": "error", // JSHINT disallow usage of expressions in statement position
+		"no-unused-labels": "error", // disallow unused labels
+		"no-useless-call": "error", // disallow unnecessary .call() and .apply()
+		"no-useless-concat": "error", // disallow unnecessary concatenation of literals or template literals
+		"no-useless-escape": "error", // disallow unnecessary escape characters
+		"no-void": "error", // disallow use of the void operator
+		"no-warning-comments": [ "off", { "terms": [ "todo", "fixme", "xxx" ], "location": "start" } ], // disallow usage of configurable warning terms in comments - e.g. TODO or FIXME
+		"no-with": "error", // JSCS disallow use of the with statement
+		"radix": "error", // require use of the second argument for parseInt()
+		"vars-on-top": "off", // require declaration of all vars at the top of their containing scope
+		"wrap-iife": "error", // JSCS require immediate function invocation to be wrapped in parentheses
+		"yoda": "error" // require or disallow Yoda conditions
 	}
 };

--- a/rules/ecmascript6.js
+++ b/rules/ecmascript6.js
@@ -33,36 +33,36 @@ module.exports = {
 		}
 	},
 	"rules": {
-		"arrow-body-style": [ 0, "as-needed" ], // TRIAL require braces in arrow function body
-		"arrow-parens": [ 2, "as-needed" ], // require parens in arrow function arguments
-		"arrow-spacing": [ 2, { "before": true, "after": true } ], // require space before/after arrow function's arrow (fixable)
-		"constructor-super": 2, // verify calls of super() in constructors
-		"generator-star-spacing": [ 2, { "before": true, "after": false } ], // enforce spacing around the * in generator functions (fixable)
-		"no-class-assign": 2, // disallow modifying variables of class declarations
-		"no-confusing-arrow": 2, // disallow arrow functions where they could be confused with comparisons
-		"no-const-assign": 2, // disallow modifying variables that are declared using const
-		"no-dupe-class-members": 2, // disallow duplicate name in class members
-		"no-duplicate-imports": 2, // disallow duplicate module imports
-		"no-new-symbol": 2, // disallow new operators with the Symbol object
-		"no-restricted-imports": 0, // disallow specified modules when loaded by import
-		"no-this-before-super": 2, // disallow use of this/super before calling super() in constructors
-		"no-useless-computed-key": 2, // disallow unnecessary computed property keys in object literals
-		"no-useless-constructor": 2, // disallow unnecessary constructors
-		"no-useless-rename": 2, // disallow renaming import, export, and destructured assignments to the same name
-		"no-var": 2, // require let or const instead of var
-		"object-shorthand": [ 2, "always" ], // require method and property shorthand syntax for object literals
-		"prefer-arrow-callback": 2, // suggest using arrow functions as callbacks
-		"prefer-const": 2, // suggest using const declaration for variables that are never modified after declared
-		"prefer-numeric-literals": 0, // disallow parseInt() in favor of binary, octal, and hexadecimal literals
-		"prefer-reflect": 0, // suggest using Reflect methods where applicable
-		"prefer-rest-params": 2, // require rest parameters instead of arguments
-		"prefer-spread": 2, // suggest using the spread operator instead of .apply()
-		"prefer-template": 2, // suggest using template literals instead of strings concatenation
-		"require-yield": 2, // disallow generator functions that do not have yield
-		"rest-spread-spacing": [ 2, "never" ], // enforce spacing between rest and spread operators and their expressions
-		"sort-imports": 0, // enforce sorted import declarations within modules
-		"symbol-description": 0, // require symbol descriptions
-		"template-curly-spacing": [ 2, "always" ], // require or disallow spacing around embedded expressions of template strings
-		"yield-star-spacing": 0 // require or disallow spacing around the * in yield* expressions
+		"arrow-body-style": [ "off", "as-needed" ], // TRIAL require braces in arrow function body
+		"arrow-parens": [ "error", "as-needed" ], // require parens in arrow function arguments
+		"arrow-spacing": [ "error", { "before": true, "after": true } ], // require space before/after arrow function's arrow (fixable)
+		"constructor-super": "error", // verify calls of super() in constructors
+		"generator-star-spacing": [ "error", { "before": true, "after": false } ], // enforce spacing around the * in generator functions (fixable)
+		"no-class-assign": "error", // disallow modifying variables of class declarations
+		"no-confusing-arrow": "error", // disallow arrow functions where they could be confused with comparisons
+		"no-const-assign": "error", // disallow modifying variables that are declared using const
+		"no-dupe-class-members": "error", // disallow duplicate name in class members
+		"no-duplicate-imports": "error", // disallow duplicate module imports
+		"no-new-symbol": "error", // disallow new operators with the Symbol object
+		"no-restricted-imports": "off", // disallow specified modules when loaded by import
+		"no-this-before-super": "error", // disallow use of this/super before calling super() in constructors
+		"no-useless-computed-key": "error", // disallow unnecessary computed property keys in object literals
+		"no-useless-constructor": "error", // disallow unnecessary constructors
+		"no-useless-rename": "error", // disallow renaming import, export, and destructured assignments to the same name
+		"no-var": "error", // require let or const instead of var
+		"object-shorthand": [ "error", "always" ], // require method and property shorthand syntax for object literals
+		"prefer-arrow-callback": "error", // suggest using arrow functions as callbacks
+		"prefer-const": "error", // suggest using const declaration for variables that are never modified after declared
+		"prefer-numeric-literals": "off", // disallow parseInt() in favor of binary, octal, and hexadecimal literals
+		"prefer-reflect": "off", // suggest using Reflect methods where applicable
+		"prefer-rest-params": "error", // require rest parameters instead of arguments
+		"prefer-spread": "error", // suggest using the spread operator instead of .apply()
+		"prefer-template": "error", // suggest using template literals instead of strings concatenation
+		"require-yield": "error", // disallow generator functions that do not have yield
+		"rest-spread-spacing": [ "error", "never" ], // enforce spacing between rest and spread operators and their expressions
+		"sort-imports": "off", // enforce sorted import declarations within modules
+		"symbol-description": "off", // require symbol descriptions
+		"template-curly-spacing": [ "error", "always" ], // require or disallow spacing around embedded expressions of template strings
+		"yield-star-spacing": "off" // require or disallow spacing around the * in yield* expressions
 	}
 };

--- a/rules/nodejs-and-commonjs.js
+++ b/rules/nodejs-and-commonjs.js
@@ -2,16 +2,16 @@
 
 module.exports = {
 	"rules": {
-		"callback-return": 2, // enforce return after a callback
-		"global-require": 2, // enforce require() on top-level module scope
-		"handle-callback-err": 0, // enforce require() on top-level module scope
-		"no-mixed-requires": [ 2, { "grouping": true } ], //  enforce error handling in callbacks
-		"no-new-require": 2, //  disallow mixing regular variable and require declarations
-		"no-path-concat": 2, // disallow string concatenation with __dirname and __filename
-		"no-process-env": 0, // disallow use of process.env
-		"no-process-exit": 2, // disallow process.exit()
-		"no-restricted-modules": 0, // restrict usage of specified node modules
-		"no-restricted-properties": 0, // disallow certain properties on certain objects
-		"no-sync": 0 //  disallow use of synchronous methods
+		"callback-return": "error", // enforce return after a callback
+		"global-require": "error", // enforce require() on top-level module scope
+		"handle-callback-err": "off", // enforce require() on top-level module scope
+		"no-mixed-requires": [ "error", { "grouping": true } ], //  enforce error handling in callbacks
+		"no-new-require": "error", //  disallow mixing regular variable and require declarations
+		"no-path-concat": "error", // disallow string concatenation with __dirname and __filename
+		"no-process-env": "off", // disallow use of process.env
+		"no-process-exit": "error", // disallow process.exit()
+		"no-restricted-modules": "off", // restrict usage of specified node modules
+		"no-restricted-properties": "off", // disallow certain properties on certain objects
+		"no-sync": "off" //  disallow use of synchronous methods
 	}
 };

--- a/rules/possible-errors.js
+++ b/rules/possible-errors.js
@@ -2,36 +2,36 @@
 
 module.exports = {
 	"rules": {
-		"no-cond-assign": [ 2, "always" ], // JSHINT disallow assignment in conditional expressions
-		"no-console": 1, // disallow use of console in the node environment
-		"no-constant-condition": 2, // disallow use of constant expressions in conditions
-		"no-control-regex": 2, // disallow control characters in regular expressions
-		"no-debugger": 2, // JSHINT disallow use of debugger
-		"no-dupe-args": 2, // disallow duplicate arguments in functions
-		"no-dupe-keys": 2, // disallow duplicate keys when creating object literals
-		"no-duplicate-case": 2, // disallow a duplicate case label
-		"no-empty-character-class": 2, // disallow the use of empty character classes in regular expressions
-		"no-empty": 2, // JSHINT disallow empty statements
-		"no-ex-assign": 2, // disallow assigning to the exception in a catch block
-		"no-extra-boolean-cast": 2, // disallow double-negation boolean casts in a boolean context
-		"no-extra-parens": 0, // TRIAL disallow unnecessary parentheses
-		"no-extra-semi": 2, // disallow unnecessary semicolons (fixable)
-		"no-func-assign": 2, // disallow overwriting functions written as function declarations
-		"no-inner-declarations": 2, // disallow function or variable declarations in nested blocks
-		"no-invalid-regexp": 2, // disallow invalid regular expression strings in the RegExp constructor
-		"no-irregular-whitespace": 2, // disallow irregular whitespace outside of strings and comments
-		"no-negated-in-lhs": 2, // disallow negation of the left operand of an in expression
-		"no-obj-calls": 2, // disallow the use of object properties of the global object (Math and JSON) as functions
-		"no-prototype-builtins": 0, // disallow calling some Object.prototype methods directly on objects
-		"no-regex-spaces": 2, // disallow multiple spaces in a regular expression literal
-		"no-sparse-arrays": 2, //  disallow sparse arrays
-		"no-template-curly-in-string": 2, // disallow template literal placeholder syntax in regular strings
-		"no-unexpected-multiline": 2, //  Avoid code that looks like two expressions but is actually one
-		"no-unreachable": 2, // disallow unreachable statements after a return, throw, continue, or break statement
-		"no-unsafe-finally": 0, // disallow control flow statements in finally blocks
-		"no-unsafe-negation": 0, // disallow negating the left operand of relational operators
-		"use-isnan": 2, // disallow comparisons with the value NaN
-		"valid-jsdoc": 2, // Ensure JSDoc comments are valid
-		"valid-typeof": 2 // Ensure that the results of typeof are compared against a valid string
+		"no-cond-assign": [ "error", "always" ], // JSHINT disallow assignment in conditional expressions
+		"no-console": "warn", // disallow use of console in the node environment
+		"no-constant-condition": "error", // disallow use of constant expressions in conditions
+		"no-control-regex": "error", // disallow control characters in regular expressions
+		"no-debugger": "error", // JSHINT disallow use of debugger
+		"no-dupe-args": "error", // disallow duplicate arguments in functions
+		"no-dupe-keys": "error", // disallow duplicate keys when creating object literals
+		"no-duplicate-case": "error", // disallow a duplicate case label
+		"no-empty-character-class": "error", // disallow the use of empty character classes in regular expressions
+		"no-empty": "error", // JSHINT disallow empty statements
+		"no-ex-assign": "error", // disallow assigning to the exception in a catch block
+		"no-extra-boolean-cast": "error", // disallow double-negation boolean casts in a boolean context
+		"no-extra-parens": "off", // TRIAL disallow unnecessary parentheses
+		"no-extra-semi": "error", // disallow unnecessary semicolons (fixable)
+		"no-func-assign": "error", // disallow overwriting functions written as function declarations
+		"no-inner-declarations": "error", // disallow function or variable declarations in nested blocks
+		"no-invalid-regexp": "error", // disallow invalid regular expression strings in the RegExp constructor
+		"no-irregular-whitespace": "error", // disallow irregular whitespace outside of strings and comments
+		"no-negated-in-lhs": "error", // disallow negation of the left operand of an in expression
+		"no-obj-calls": "error", // disallow the use of object properties of the global object (Math and JSON) as functions
+		"no-prototype-builtins": "off", // disallow calling some Object.prototype methods directly on objects
+		"no-regex-spaces": "error", // disallow multiple spaces in a regular expression literal
+		"no-sparse-arrays": "error", //  disallow sparse arrays
+		"no-template-curly-in-string": "error", // disallow template literal placeholder syntax in regular strings
+		"no-unexpected-multiline": "error", //  Avoid code that looks like two expressions but is actually one
+		"no-unreachable": "error", // disallow unreachable statements after a return, throw, continue, or break statement
+		"no-unsafe-finally": "off", // disallow control flow statements in finally blocks
+		"no-unsafe-negation": "off", // disallow negating the left operand of relational operators
+		"use-isnan": "error", // disallow comparisons with the value NaN
+		"valid-jsdoc": "error", // Ensure JSDoc comments are valid
+		"valid-typeof": "error" // Ensure that the results of typeof are compared against a valid string
 	}
 };

--- a/rules/react.js
+++ b/rules/react.js
@@ -4,31 +4,31 @@ module.exports = {
 	"plugins": [ "react" ],
 	"rules": {
 		// List of supported rules
-		"react/display-name": 2, // Prevent missing displayName in a React component definition
-		"react/forbid-component-props:": 0, // Forbid certain props on Components
-		"react/forbid-prop-types": [ 2, { "forbid": [ "any" ] } ], // Forbid certain propTypes
-		"react/no-danger": 2, // Prevent usage of dangerous JSX properties
-		"react/no-danger-with-children": 2, // Prevent problem with children and props.dangerouslySetInnerHTML
-		"react/no-deprecated": 2, // Prevent usage of deprecated methods
-		"react/no-did-mount-set-state": 2, // Prevent usage of setState in componentDidMount
-		"react/no-did-update-set-state": 2, // Prevent usage of setState in componentDidUpdate
-		"react/no-direct-mutation-state": 2, // Prevent direct mutation of this.state
-		"react/no-find-dom-node": 0, // Prevent usage of findDOMNode
-		"react/no-is-mounted": 2, // Prevent usage of isMounted
-		"react/no-multi-comp": [ 2, { "ignoreStateless": true } ], // Prevent multiple component definition per file
-		"react/no-render-return-value": 2, // Prevent usage of the return value of React.render
-		"react/no-set-state": 0, // Prevent usage of setState
-		"react/no-string-refs": 0, // Prevent using string references in ref attribute.
-		"react/no-unknown-property": 2, // Prevent usage of unknown DOM property
-		"react/no-unused-prop-types": 2, // Prevent definitions of unused prop types
-		"react/prefer-es6-class": 0, // Prefer es6 class instead of createClass for React Components
-		"react/prefer-stateless-function": 1, // Enforce stateless React Components to be written as a pure function
-		"react/prop-types": 2, // Prevent missing props validation in a React component definition
-		"react/react-in-jsx-scope": 2, // Prevent missing React when using JSX
-		"react/require-optimization": 0, // Enforce React components to have a shouldComponentUpdate method
-		"react/require-render-return": 2, // Enforce ES5 or ES6 class for returning value in render function
-		"react/self-closing-comp": 2, // Prevent extra closing tags for components without children
-		"react/sort-comp": [ 2, {
+		"react/display-name": "error", // Prevent missing displayName in a React component definition
+		"react/forbid-component-props:": "off", // Forbid certain props on Components
+		"react/forbid-prop-types": [ "error", { "forbid": [ "any" ] } ], // Forbid certain propTypes
+		"react/no-danger": "error", // Prevent usage of dangerous JSX properties
+		"react/no-danger-with-children": "error", // Prevent problem with children and props.dangerouslySetInnerHTML
+		"react/no-deprecated": "error", // Prevent usage of deprecated methods
+		"react/no-did-mount-set-state": "error", // Prevent usage of setState in componentDidMount
+		"react/no-did-update-set-state": "error", // Prevent usage of setState in componentDidUpdate
+		"react/no-direct-mutation-state": "error", // Prevent direct mutation of this.state
+		"react/no-find-dom-node": "off", // Prevent usage of findDOMNode
+		"react/no-is-mounted": "error", // Prevent usage of isMounted
+		"react/no-multi-comp": [ "error", { "ignoreStateless": true } ], // Prevent multiple component definition per file
+		"react/no-render-return-value": "error", // Prevent usage of the return value of React.render
+		"react/no-set-state": "off", // Prevent usage of setState
+		"react/no-string-refs": "off", // Prevent using string references in ref attribute.
+		"react/no-unknown-property": "error", // Prevent usage of unknown DOM property
+		"react/no-unused-prop-types": "error", // Prevent definitions of unused prop types
+		"react/prefer-es6-class": "off", // Prefer es6 class instead of createClass for React Components
+		"react/prefer-stateless-function": "warn", // Enforce stateless React Components to be written as a pure function
+		"react/prop-types": "error", // Prevent missing props validation in a React component definition
+		"react/react-in-jsx-scope": "error", // Prevent missing React when using JSX
+		"react/require-optimization": "off", // Enforce React components to have a shouldComponentUpdate method
+		"react/require-render-return": "error", // Enforce ES5 or ES6 class for returning value in render function
+		"react/self-closing-comp": "error", // Prevent extra closing tags for components without children
+		"react/sort-comp": [ "error", {
 			"order": [
 				"mixins",
 				"lux",
@@ -52,30 +52,30 @@ module.exports = {
 				]
 			}
 		} ], // Enforce component methods order
-		"react/style-prop-object": 2, // Enforce style prop value being an object
+		"react/style-prop-object": "error", // Enforce style prop value being an object
 		// JSX-specific rules
-		"react/jsx-boolean-value": [ 0, "always" ], // Enforce boolean attributes notation in JSX
-		"react/jsx-closing-bracket-location": [ 1, { "location": "after-props" } ], // Validate closing bracket location in JSX
-		"react/jsx-curly-spacing": [ 2, "always" ], // Enforce or disallow spaces inside of curly braces in JSX attributes
-		"react/jsx-equals-spacing": [ 2, "never" ], // Enforce or disallow spaces around equal signs in JSX attributes (fixable)
-		"react/jsx-filename-extension": 2, // Restrict file extensions that may contain JSX
-		"react/jsx-first-prop-new-line": 0, // Enforce position of the first prop in JSX
-		"react/jsx-handler-names": [ 0, { "eventHandlerPrefix": "handle", "eventHandlerPropPrefix": "on" } ], // Enforce event handler naming conventions in JSX
-		"react/jsx-indent": [ 2, "tab" ], // Validate JSX indentation
-		"react/jsx-indent-props": [ 2, "tab" ], // Validate props indentation in JSX
-		"react/jsx-key": 2, // Validate JSX has key prop when in array or iterator
-		"react/jsx-max-props-per-line": [ 2, { "maximum": 10 } ], // Limit maximum of props on a single line in JSX
-		"react/jsx-no-bind": [ 0 ], // Prevent usage of .bind() and arrow functions in JSX props
-		"react/jsx-no-comment-textnodes": 2, // Prevent comments from being inserted as text nodes
-		"react/jsx-no-duplicate-props": [ 2, { "ignoreCase": false } ], // Prevent duplicate props in JSX
-		"react/jsx-no-literals": 0, // Prevent usage of unwrapped JSX strings
-		"react/jsx-no-target-blank": 2, // Prevent usage of unsafe target='_blank'
-		"react/jsx-no-undef": 2, // Disallow undeclared variables in JSX
-		"react/jsx-pascal-case": 0, // Enforce PascalCase for user-defined JSX components
-		"react/jsx-sort-props": 0, // Enforce props alphabetical sorting
-		"react/jsx-space-before-closing": 2, // Validate spacing before closing bracket in JSX (fixable)
-		"react/jsx-uses-react": 2, // Prevent React to be incorrectly marked as unused
-		"react/jsx-uses-vars": 2, // Prevent variables used in JSX to be incorrectly marked as unused
-		"react/jsx-wrap-multilines": 2 // Prevent missing parentheses around multilines JSX
+		"react/jsx-boolean-value": [ "off", "always" ], // Enforce boolean attributes notation in JSX
+		"react/jsx-closing-bracket-location": [ "warn", { "location": "after-props" } ], // Validate closing bracket location in JSX
+		"react/jsx-curly-spacing": [ "error", "always" ], // Enforce or disallow spaces inside of curly braces in JSX attributes
+		"react/jsx-equals-spacing": [ "error", "never" ], // Enforce or disallow spaces around equal signs in JSX attributes (fixable)
+		"react/jsx-filename-extension": "error", // Restrict file extensions that may contain JSX
+		"react/jsx-first-prop-new-line": "off", // Enforce position of the first prop in JSX
+		"react/jsx-handler-names": [ "off", { "eventHandlerPrefix": "handle", "eventHandlerPropPrefix": "on" } ], // Enforce event handler naming conventions in JSX
+		"react/jsx-indent": [ "error", "tab" ], // Validate JSX indentation
+		"react/jsx-indent-props": [ "error", "tab" ], // Validate props indentation in JSX
+		"react/jsx-key": "error", // Validate JSX has key prop when in array or iterator
+		"react/jsx-max-props-per-line": [ "error", { "maximum": 10 } ], // Limit maximum of props on a single line in JSX
+		"react/jsx-no-bind": [ "off" ], // Prevent usage of .bind() and arrow functions in JSX props
+		"react/jsx-no-comment-textnodes": "error", // Prevent comments from being inserted as text nodes
+		"react/jsx-no-duplicate-props": [ "error", { "ignoreCase": false } ], // Prevent duplicate props in JSX
+		"react/jsx-no-literals": "off", // Prevent usage of unwrapped JSX strings
+		"react/jsx-no-target-blank": "error", // Prevent usage of unsafe target='_blank'
+		"react/jsx-no-undef": "error", // Disallow undeclared variables in JSX
+		"react/jsx-pascal-case": "off", // Enforce PascalCase for user-defined JSX components
+		"react/jsx-sort-props": "off", // Enforce props alphabetical sorting
+		"react/jsx-space-before-closing": "error", // Validate spacing before closing bracket in JSX (fixable)
+		"react/jsx-uses-react": "error", // Prevent React to be incorrectly marked as unused
+		"react/jsx-uses-vars": "error", // Prevent variables used in JSX to be incorrectly marked as unused
+		"react/jsx-wrap-multilines": "error" // Prevent missing parentheses around multilines JSX
 	}
 };

--- a/rules/strict-mode.js
+++ b/rules/strict-mode.js
@@ -2,6 +2,6 @@
 
 module.exports = {
 	"rules": {
-		"strict": [ 2, "never" ] // controls location of Use Strict Directives
+		"strict": [ "error", "never" ] // controls location of Use Strict Directives
 	}
 };

--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -4,7 +4,7 @@ module.exports = {
 	"rules": {
 		"array-bracket-spacing": [ "error", "always" ], // JSCS enforce spacing inside array brackets (fixable)
 		"block-spacing": [ "error", "always" ], // disallow or enforce spaces inside of single line blocks (fixable)
-		"brace-style": [ "error", "1tbs" ], // JSCS enforce one true brace style
+		"brace-style": [ "error", "1tbs", { allowSingleLine: true } ], // JSCS enforce one true brace style
 		"camelcase": [ "error", { "properties": "always" } ], // JSCS require camel case names
 		"comma-dangle": [ "error", "never" ], // JSCS disallow or enforce trailing commas
 		"comma-spacing": [ "error", { "before": false, "after": true } ], // enforce spacing before and after comma (fixable)
@@ -75,17 +75,17 @@ module.exports = {
 		"operator-linebreak": [ "error", "after", { "overrides": { "?": "after", ":": "after" } } ], // JSCS enforce operators to be placed before or after line breaks
 		"padded-blocks": [ "error", "never" ], // JSCS enforce padding within blocks
 		"quote-props": [ "error", "as-needed", { "keywords": false } ], // JSCS require quotes around object literal property names
-		"quotes": [ "error", "double", "avoid-escape" ], // JSCS specify whether backticks, double or single quotes should be used (fixable)
+		"quotes": [ "error", "double", { avoidEscape: true } ], // JSCS specify whether backticks, double or single quotes should be used (fixable)
 		"require-jsdoc": [ "off" ], // Require JSDoc comment
 		"semi-spacing": [ "error", { "before": false, "after": true } ], // enforce spacing before and after semicolons
 		"semi": [ "error", "always" ], // JSCS require or disallow use of semicolons instead of ASI (fixable)
 		"sort-keys": "off", // requires object keys to be sorted
 		"sort-vars": "off", // sort variables within the same declaration block
 		"space-before-blocks": [ "error", "always" ], // JSCS require or disallow a space before blocks (fixable)
-		"space-before-function-paren": [ "error", "never" ], // JSCS require or disallow a space before function opening parenthesis (fixable)
+		"space-before-function-paren": [ "error", { "anonymous": "ignore", "named": "never" } ], // JSCS require or disallow a space before function opening parenthesis (fixable)
 		"space-in-parens": [ "error", "always" ], // JSCS require or disallow spaces inside parentheses
 		"space-infix-ops": "error", // JSCS require spaces around operators (fixable)
-		"space-unary-ops": "error", // JSCS require or disallow spaces before/after unary operators (fixable)
+		"space-unary-ops": [ "error", { "words": false, "nonwords": false } ], // JSCS require or disallow spaces before/after unary operators (fixable)
 		"spaced-comment": [ "error", "always" ], // require or disallow a space immediately following the // or /* in a comment
 		"unicode-bom": "off", // require or disallow Unicode byte order mark (BOM)
 		"wrap-regex": "off" // require regex literals to be wrapped in parentheses

--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -2,26 +2,26 @@
 
 module.exports = {
 	"rules": {
-		"array-bracket-spacing": [ 2, "always" ], // JSCS enforce spacing inside array brackets (fixable)
-		"block-spacing": [ 2, "always" ], // disallow or enforce spaces inside of single line blocks (fixable)
-		"brace-style": [ 2, "1tbs" ], // JSCS enforce one true brace style
-		"camelcase": [ 2, { "properties": "always" } ], // JSCS require camel case names
-		"comma-dangle": [ 2, "never" ], // JSCS disallow or enforce trailing commas
-		"comma-spacing": [ 2, { "before": false, "after": true } ], // enforce spacing before and after comma (fixable)
-		"comma-style": [ 2, "last" ], // JSCS enforce one true comma style
-		"computed-property-spacing": [ 2, "always" ], // require or disallow padding inside computed properties (fixable)
-		"consistent-this": [ 2, "self" ], // enforce consistent naming when capturing the current execution context
-		"eol-last": 2, // JSCS enforce newline at the end of file, with no multiple empty lines (fixable)
-		"func-call-spacing": [ 2, "never" ], // require or disallow spacing between function identifiers and their invocations
-		"func-names": 0, // require function expressions to have a name
-		"func-style": 0, // enforce use of function declarations or expressions
-		"id-blacklist": 0, // disallow specified identifiers
-		"id-length": [ 2, { "min": 1, "max": 100, "properties": "always", "exceptions": [] } ], // this option enforces minimum and maximum identifier lengths (variable names, property names etc.)
-		"id-match": 0, // require identifiers to match the provided regular expression
-		"indent": [ 2, "tab", { "SwitchCase": 1 } ], // JSCS specify tab or space width for your code (fixable)
-		"jsx-quotes": [ 2, "prefer-double" ], // specify whether double or single quotes should be used in JSX attributes
-		"key-spacing": [ 2, { "beforeColon": false, "afterColon": true } ], // JSCS enforce spacing between keys and values in object literal properties
-		"keyword-spacing": [ 2, {
+		"array-bracket-spacing": [ "error", "always" ], // JSCS enforce spacing inside array brackets (fixable)
+		"block-spacing": [ "error", "always" ], // disallow or enforce spaces inside of single line blocks (fixable)
+		"brace-style": [ "error", "1tbs" ], // JSCS enforce one true brace style
+		"camelcase": [ "error", { "properties": "always" } ], // JSCS require camel case names
+		"comma-dangle": [ "error", "never" ], // JSCS disallow or enforce trailing commas
+		"comma-spacing": [ "error", { "before": false, "after": true } ], // enforce spacing before and after comma (fixable)
+		"comma-style": [ "error", "last" ], // JSCS enforce one true comma style
+		"computed-property-spacing": [ "error", "always" ], // require or disallow padding inside computed properties (fixable)
+		"consistent-this": [ "error", "self" ], // enforce consistent naming when capturing the current execution context
+		"eol-last": "error", // JSCS enforce newline at the end of file, with no multiple empty lines (fixable)
+		"func-call-spacing": [ "error", "never" ], // require or disallow spacing between function identifiers and their invocations
+		"func-names": "off", // require function expressions to have a name
+		"func-style": "off", // enforce use of function declarations or expressions
+		"id-blacklist": "off", // disallow specified identifiers
+		"id-length": [ "error", { "min": 1, "max": 100, "properties": "always", "exceptions": [] } ], // this option enforces minimum and maximum identifier lengths (variable names, property names etc.)
+		"id-match": "off", // require identifiers to match the provided regular expression
+		"indent": [ "error", "tab", { "SwitchCase": 1 } ], // JSCS specify tab or space width for your code (fixable)
+		"jsx-quotes": [ "error", "prefer-double" ], // specify whether double or single quotes should be used in JSX attributes
+		"key-spacing": [ "error", { "beforeColon": false, "afterColon": true } ], // JSCS enforce spacing between keys and values in object literal properties
+		"keyword-spacing": [ "error", {
 			"before": true, // require a space before certain keywords (fixable)
 			"after": true, // JSCS require a space after certain keywords (fixable)
 			"overrides": { // JSCS require a space after return, throw, and case (fixable)
@@ -30,64 +30,64 @@ module.exports = {
 				"case": { "after": true }
 			}
 		} ], // enforce consistent spacing before and after keywords
-		"line-comment-position": 0, // enforce position of line comments
-		"linebreak-style": [ 2, "unix" ], // JSCS disallow mixed 'LF' and 'CRLF' as linebreaks
-		"lines-around-comment": 0, // JSCS enforce empty lines around comments
-		"lines-around-directive": 0, // require or disallow newlines around directives
-		"max-depth": [ 2, 5 ], // specify the maximum depth that blocks can be nested
-		"max-len": 0, // specify the maximum length of a line in your program
-		"max-lines": [ 2, 100 ], // enforce a maximum number of lines per file
-		"max-nested-callbacks": [ 2, 3 ], // specify the maximum depth callbacks can be nested
-		"max-params": [ 2, 5 ], // limits the number of parameters that can be used in the function declaration.
-		"max-statements-per-line": [ 2, { "max": 5 } ], // enforce a maximum number of statements allowed per line
-		"max-statements": [ 2, 25 ], // specify the maximum number of statement allowed in a function
-		"multiline-ternary": 0, // enforce newlines between operands of ternary expressions
-		"new-cap": 2, // JSCS require a capital letter for constructors
-		"new-parens": 2, // disallow the omission of parentheses when invoking a constructor with no arguments
-		"newline-after-var": [ 0, "always" ], // require or disallow an empty newline after variable declarations
-		"newline-before-return": 0, // require an empty line before return statements
-		"newline-per-chained-call": 0, // require a newline after each call in a method chain
-		"no-array-constructor": 2, // disallow use of the Array constructor
-		"no-bitwise": 0, // JSHINT disallow use of bitwise operators
-		"no-continue": 2, // disallow use of the continue statement
-		"no-inline-comments": 0, // disallow comments inline after code
-		"no-lonely-if": 2, // disallow if as the only statement in an else block
-		"no-mixed-operators": 2, // disallow mixed binary operators
-		"no-mixed-spaces-and-tabs": 2, // JSCS disallow mixed spaces and tabs for indentation
-		"no-multiple-empty-lines": [ 2, { max: 2 } ], // JSCS disallow multiple empty lines
-		"no-negated-condition": 0, // TRIAL disallow negated conditions
-		"no-nested-ternary": 2, // disallow nested ternary expressions
-		"no-new-object": 2, // disallow the use of the Object constructor
-		"no-plusplus": 0, // JSHINT disallow use of unary operators, ++ and --
-		"no-restricted-syntax": [ 2, "WithStatement" ], // disallow use of certain syntax in code
-		"no-tabs": 0, // disallow tabs in file
-		"no-ternary": 0, // disallow the use of ternary operators
-		"no-trailing-spaces": 2, // JSCS disallow trailing whitespace at the end of lines (fixable)
-		"no-underscore-dangle": 0, // disallow dangling underscores in identifiers
-		"no-unneeded-ternary": 2, // disallow the use of ternary operators when a simpler alternative exists
-		"no-whitespace-before-property": 2, // disallow whitespace before properties
-		"object-curly-newline": 0, // enforce consistent line breaks inside braces
-		"object-curly-spacing": [ 2, "always" ], // require or disallow padding inside curly braces (fixable)
-		"object-property-newline": 0, // enforce placing object properties on separate lines
-		"one-var-declaration-per-line": 0, // require or disallow newlines around var declarations
-		"one-var": [ 2, { "initialized": "never", "uninitialized": "always" } ], // JSCS require or disallow one variable declaration per function
-		"operator-assignment": [ 2, "always" ], // require assignment operator shorthand where possible or prohibit it entirely
-		"operator-linebreak": [ 2, "after", { "overrides": { "?": "after", ":": "after" } } ], // JSCS enforce operators to be placed before or after line breaks
-		"padded-blocks": [ 2, "never" ], // JSCS enforce padding within blocks
-		"quote-props": [ 2, "as-needed", { "keywords": false } ], // JSCS require quotes around object literal property names
-		"quotes": [ 2, "double", "avoid-escape" ], // JSCS specify whether backticks, double or single quotes should be used (fixable)
-		"require-jsdoc": [ 0 ], // Require JSDoc comment
-		"semi-spacing": [ 2, { "before": false, "after": true } ], // enforce spacing before and after semicolons
-		"semi": [ 2, "always" ], // JSCS require or disallow use of semicolons instead of ASI (fixable)
-		"sort-keys": 0, // requires object keys to be sorted
-		"sort-vars": 0, // sort variables within the same declaration block
-		"space-before-blocks": [ 2, "always" ], // JSCS require or disallow a space before blocks (fixable)
-		"space-before-function-paren": [ 2, "never" ], // JSCS require or disallow a space before function opening parenthesis (fixable)
-		"space-in-parens": [ 2, "always" ], // JSCS require or disallow spaces inside parentheses
-		"space-infix-ops": 2, // JSCS require spaces around operators (fixable)
-		"space-unary-ops": 2, // JSCS require or disallow spaces before/after unary operators (fixable)
-		"spaced-comment": [ 2, "always" ], // require or disallow a space immediately following the // or /* in a comment
-		"unicode-bom": 0, // require or disallow Unicode byte order mark (BOM)
-		"wrap-regex": 0 // require regex literals to be wrapped in parentheses
+		"line-comment-position": "off", // enforce position of line comments
+		"linebreak-style": [ "error", "unix" ], // JSCS disallow mixed 'LF' and 'CRLF' as linebreaks
+		"lines-around-comment": "off", // JSCS enforce empty lines around comments
+		"lines-around-directive": "off", // require or disallow newlines around directives
+		"max-depth": [ "error", 5 ], // specify the maximum depth that blocks can be nested
+		"max-len": "off", // specify the maximum length of a line in your program
+		"max-lines": [ "error", 100 ], // enforce a maximum number of lines per file
+		"max-nested-callbacks": [ "error", 3 ], // specify the maximum depth callbacks can be nested
+		"max-params": [ "error", 5 ], // limits the number of parameters that can be used in the function declaration.
+		"max-statements-per-line": [ "error", { "max": 5 } ], // enforce a maximum number of statements allowed per line
+		"max-statements": [ "error", 25 ], // specify the maximum number of statement allowed in a function
+		"multiline-ternary": "off", // enforce newlines between operands of ternary expressions
+		"new-cap": "error", // JSCS require a capital letter for constructors
+		"new-parens": "error", // disallow the omission of parentheses when invoking a constructor with no arguments
+		"newline-after-var": [ "off", "always" ], // require or disallow an empty newline after variable declarations
+		"newline-before-return": "off", // require an empty line before return statements
+		"newline-per-chained-call": "off", // require a newline after each call in a method chain
+		"no-array-constructor": "error", // disallow use of the Array constructor
+		"no-bitwise": "off", // JSHINT disallow use of bitwise operators
+		"no-continue": "error", // disallow use of the continue statement
+		"no-inline-comments": "off", // disallow comments inline after code
+		"no-lonely-if": "error", // disallow if as the only statement in an else block
+		"no-mixed-operators": "error", // disallow mixed binary operators
+		"no-mixed-spaces-and-tabs": "error", // JSCS disallow mixed spaces and tabs for indentation
+		"no-multiple-empty-lines": [ "error", { max: 2 } ], // JSCS disallow multiple empty lines
+		"no-negated-condition": "off", // TRIAL disallow negated conditions
+		"no-nested-ternary": "error", // disallow nested ternary expressions
+		"no-new-object": "error", // disallow the use of the Object constructor
+		"no-plusplus": "off", // JSHINT disallow use of unary operators, ++ and --
+		"no-restricted-syntax": [ "error", "WithStatement" ], // disallow use of certain syntax in code
+		"no-tabs": "off", // disallow tabs in file
+		"no-ternary": "off", // disallow the use of ternary operators
+		"no-trailing-spaces": "error", // JSCS disallow trailing whitespace at the end of lines (fixable)
+		"no-underscore-dangle": "off", // disallow dangling underscores in identifiers
+		"no-unneeded-ternary": "error", // disallow the use of ternary operators when a simpler alternative exists
+		"no-whitespace-before-property": "error", // disallow whitespace before properties
+		"object-curly-newline": "off", // enforce consistent line breaks inside braces
+		"object-curly-spacing": [ "error", "always" ], // require or disallow padding inside curly braces (fixable)
+		"object-property-newline": "off", // enforce placing object properties on separate lines
+		"one-var-declaration-per-line": "off", // require or disallow newlines around var declarations
+		"one-var": [ "error", { "initialized": "never", "uninitialized": "always" } ], // JSCS require or disallow one variable declaration per function
+		"operator-assignment": [ "error", "always" ], // require assignment operator shorthand where possible or prohibit it entirely
+		"operator-linebreak": [ "error", "after", { "overrides": { "?": "after", ":": "after" } } ], // JSCS enforce operators to be placed before or after line breaks
+		"padded-blocks": [ "error", "never" ], // JSCS enforce padding within blocks
+		"quote-props": [ "error", "as-needed", { "keywords": false } ], // JSCS require quotes around object literal property names
+		"quotes": [ "error", "double", "avoid-escape" ], // JSCS specify whether backticks, double or single quotes should be used (fixable)
+		"require-jsdoc": [ "off" ], // Require JSDoc comment
+		"semi-spacing": [ "error", { "before": false, "after": true } ], // enforce spacing before and after semicolons
+		"semi": [ "error", "always" ], // JSCS require or disallow use of semicolons instead of ASI (fixable)
+		"sort-keys": "off", // requires object keys to be sorted
+		"sort-vars": "off", // sort variables within the same declaration block
+		"space-before-blocks": [ "error", "always" ], // JSCS require or disallow a space before blocks (fixable)
+		"space-before-function-paren": [ "error", "never" ], // JSCS require or disallow a space before function opening parenthesis (fixable)
+		"space-in-parens": [ "error", "always" ], // JSCS require or disallow spaces inside parentheses
+		"space-infix-ops": "error", // JSCS require spaces around operators (fixable)
+		"space-unary-ops": "error", // JSCS require or disallow spaces before/after unary operators (fixable)
+		"spaced-comment": [ "error", "always" ], // require or disallow a space immediately following the // or /* in a comment
+		"unicode-bom": "off", // require or disallow Unicode byte order mark (BOM)
+		"wrap-regex": "off" // require regex literals to be wrapped in parentheses
 	}
 };

--- a/rules/variables.js
+++ b/rules/variables.js
@@ -2,17 +2,17 @@
 
 module.exports = {
 	"rules": {
-		"init-declarations": [ 2, "always" ], //  enforce or disallow variable initializations at definition
-		"no-catch-shadow": 2, // disallow the catch clause parameter name being the same as a variable in the outer scope
-		"no-delete-var": 2, // disallow deletion of variables
-		"no-label-var": 2, // disallow labels that share a name with a variable
-		"no-restricted-globals": 0, // disallow specified global variables
-		"no-shadow-restricted-names": 2, // disallow shadowing of names such as arguments
-		"no-shadow": 2, // JSHINT disallow declaration of variables already declared in the outer scope
-		"no-undef-init": 2, // disallow use of undefined when initializing variables
-		"no-undef": 2, // JSHINT disallow use of undeclared variables unless mentioned in a /*global */ block
-		"no-undefined": 0, // disallow use of undefined variable
-		"no-unused-vars": [ 2, { "vars": "all", "args": "none" } ], // JSHINT disallow declaration of variables that are not used in the code
-		"no-use-before-define": [ 2, "nofunc" ] // JSHINT disallow use of variables before they are defined
+		"init-declarations": [ "error", "always" ], //  enforce or disallow variable initializations at definition
+		"no-catch-shadow": "error", // disallow the catch clause parameter name being the same as a variable in the outer scope
+		"no-delete-var": "error", // disallow deletion of variables
+		"no-label-var": "error", // disallow labels that share a name with a variable
+		"no-restricted-globals": "off", // disallow specified global variables
+		"no-shadow-restricted-names": "error", // disallow shadowing of names such as arguments
+		"no-shadow": "error", // JSHINT disallow declaration of variables already declared in the outer scope
+		"no-undef-init": "error", // disallow use of undefined when initializing variables
+		"no-undef": "error", // JSHINT disallow use of undeclared variables unless mentioned in a /*global */ block
+		"no-undefined": "off", // disallow use of undefined variable
+		"no-unused-vars": [ "error", { "vars": "all", "args": "none" } ], // JSHINT disallow declaration of variables that are not used in the code
+		"no-use-before-define": [ "error", "nofunc" ] // JSHINT disallow use of variables before they are defined
 	}
 };


### PR DESCRIPTION
This PR includes a couple of different updates:

1) It updates all of our rule definitions to use the new string-based syntax, converting `0`, `1` and `2` with `off`, `warn` and `error` respectively.
2) It updates the values of our rule definitions to match the values we had previously set for JSCS for static analysis of our code. This is a movement toward moving away from the use of the deprecated JSCS in our projects.

The following list is a list of ESLint rules and their settings generated by running the Polyjuice tool. Each rule has an indicator _that is a *best guess*_ as to whether or not the rule was automatically fixable by JSCS, vs whether it is currently automatically fixable by ESLint. It should be clearly noted that there does not exist (that I was able to find) a definitive, exhaustive list of JSCS rules that includes an indication whether or not the rule is automatically fixable with the tool. This list includes ONLY the rules that we had configured in our `.jscsrc` file in the web-board-slice project, as converted to ESLint rules by Polyjuice. The indicator in this last as to whether it is autofixable by JSCS is based on an examination of indicators in [this pull request for the project](https://github.com/jscs-dev/node-jscs/pull/2023/files) (which, it should be noted, was never merged, and is certainly out-of-date, and likely not exhaustive), and validation of the existence of the rule in [this list of rule definitions in the code repository for JSCS](https://github.com/jscs-dev/node-jscs/tree/master/lib/rules), and an indicator on the aforementioned PR as to whether or not it was fixable. It is very possible, perhaps even likely, that it is not accurate. As I mentioned, this was a best-guess on my part.

Chart Legend:

— = not automatically fixable
✓ = automatically fixable
? = unable to verify whether or not the rule is automatically fixable


|Rule|JSCS|ESLint|
|----|----|------|
|"no-with"|—| —|
|"brace-style"|—|✓|
|"no-mixed-spaces-and-tabs"|—|—|
|"no-multiple-empty-lines"|✓|✓|
|"no-multi-str"|—|—|
|"no-multi-spaces"|✓|✓|
|"one-var"|—|—|
|"dot-location"|?|✓|
|"operator-linebreak"|✓|✓|
|"padded-blocks"|✓|✓|
|"quote-props"|✓|✓|
|"key-spacing"|✓|✓|
|"space-unary-ops"|✓|✓|
|"space-before-function-paren”|✓|✓|
|“func-call-spacing”|✓|✓|
|"comma-dangle"|✓|✓|
|"no-trailing-spaces"|✓|✓|
|"camelcase"|—|—|
|"comma-style"|✓|✓|
|"curly"|—|✓|
|"dot-notation"|—|✓|
|"eol-last"|✓|✓|
|"wrap-iife"|—|✓|
|"semi"|✓|✓|
|"space-infix-ops"|✓|✓|
|"keyword-spacing"|✓|✓|
|"space-before-blocks"|✓|✓|
|"array-bracket-spacing"|—|✓|
|"space-in-parens"|—|✓|
|"indent"|—	|✓|
|"linebreak-style"|—|✓|
|"quotes"|✓|✓|
