### PR TITLE
Removed no-unused-expressions override from test.js

### DIFF
--- a/spec/test.js
+++ b/spec/test.js
@@ -1,6 +1,6 @@
 const should = require( "chai" ).should(); // eslint-disable-line no-unused-vars
 const rules = require( "../test" );
-const IGNORED_RULES = [ "no-unused-expressions", "no-magic-numbers", "init-declarations", "react/prop-types", "react/display-name", "react/no-multi-comp", "react/prefer-stateless-function" ];
+const IGNORED_RULES = [ "no-magic-numbers", "init-declarations", "react/prop-types", "react/display-name", "react/no-multi-comp", "react/prefer-stateless-function" ];
 
 describe( "Test", function() {
 	describe( "Environment", function() {

--- a/test.js
+++ b/test.js
@@ -6,7 +6,6 @@ module.exports = {
 		"max-nested-callbacks": [ "error", 15 ],
 		"max-lines": [ "error", { "max": 2500 } ],
 		"max-statements": [ "error", { "max": 1000 } ],
-		"no-unused-expressions": "off",
 		"no-magic-numbers": "off",
 		"init-declarations": "off",
 		"react/prop-types": "off",


### PR DESCRIPTION
For a long time this rule was turned on in our projects in the spec folder overriding the value in eslint-config-leankit, which turned it off for tests. This removes the override to turn it off because we need it to catch errors like `should.be.true` in our specs when it should be `should.be.true()`