### PR TITLE
Changed to use babel's no-invalid-this

### DIFF
--- a/babel.js
+++ b/babel.js
@@ -1,5 +1,8 @@
 module.exports = {
 	"parser": "babel-eslint",
 	"plugins": [ "babel" ],
-	"rules": {}
+	"rules": {
+		"no-invalid-this": "off",
+		"babel/no-invalid-this": "error"
+	}
 };


### PR DESCRIPTION
This is so that we can use React state 3 class field properties without ESLint complaining about no-invalid-this.