### PR TITLE
Locked down eslint-plugin-react to ~7.12.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
     "eslint": "^4.8.0",
     "eslint-plugin-babel": "^4.1.2",
     "eslint-plugin-jsx-a11y": "^6.0.2",
-    "eslint-plugin-react": "^7.4.0"
+    "eslint-plugin-react": "~7.12.4"
   }
 }


### PR DESCRIPTION
1. Pull down this PR and `npm pack` from the command-line
2. In another terminal, take a project like `web-account-slice`
3. Remove the `"react/prop-types": [ "warn" ]` rule from `web-account-slice`'s `.eslintrc`
4. From `web-account-slice` install the packed `eslint-plugin-leankit` with `npm i ../eslint-config-leankit/eslint-config-leankit-4.5.0.tgz`
5. Remove the ESLint cache and run the lint task with `rm .eslintcache && npm run lint`
6. There should be no errors or warnings from ESLint